### PR TITLE
Add basic TLS support

### DIFF
--- a/django_python3_ldap/conf.py
+++ b/django_python3_ldap/conf.py
@@ -41,6 +41,11 @@ class LazySettings():
         default = "ldap://localhost:389",
     )
 
+    LDAP_AUTH_USE_TLS = LazySetting(
+        name = "LDAP_AUTH_USE_TLS",
+        default = False,
+    )
+
     # The LDAP search base for looking up users.
     LDAP_AUTH_SEARCH_BASE = LazySetting(
         name = "LDAP_AUTH_SEARCH_BASE",

--- a/django_python3_ldap/ldap.py
+++ b/django_python3_ldap/ldap.py
@@ -145,6 +145,10 @@ def connection(*args, **kwargs):
         username_dn = None
     # Make the connection.
     with ldap3.Connection(ldap3.Server(settings.LDAP_AUTH_URL), user=username_dn, password=password, auto_bind=ldap3.AUTO_BIND_NONE) as c:
+
+        if settings.LDAP_AUTH_USE_TLS:
+            c.start_tls()
+
         # Attempt authentication, if required.
         if user_identifier and not c.bind():
             yield None


### PR DESCRIPTION
I was trying to use this package, but the LDAP server that I needed to connect to requires TLS. 

This pull request adds a setting to enable initiating TLS after connection.