### PR TITLE
Simple LDAP login with username/email and password

### DIFF
--- a/django_python3_ldap/conf.py
+++ b/django_python3_ldap/conf.py
@@ -98,5 +98,17 @@ class LazySettings():
         default = "",
     )
 
+    # user for simple authentication
+    LDAP_AUTH_SIMPLEAUTH_USER = LazySetting(
+        name = "LDAP_AUTH_SIMPLEAUTH_USER",
+        default = "",
+    )
+
+    # password for simple authentication
+    LDAP_AUTH_SIMPLEAUTH_PASSWORD = LazySetting(
+        name = "LDAP_AUTH_SIMPLEAUTH_PASSWORD",
+        default = "",
+    )
+
 
 settings = LazySettings(settings)


### PR DESCRIPTION
Introduced two new settings: `LDAP_AUTH_SIMPLEAUTH_USER`, `LDAP_AUTH_SIMPLEAUTH_PASSWORD`, which when given, will be used as credentials for the connection.

Committing this little change back. We needed a simpler login to LDAP with username and password instead of login with a user dn (which apparently breaks in our setup), which django-ldap-auth provided, but yours didn't. Please let us know what you think :-)