### PR TITLE
Fix dependencies with new package ldap3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     packages = find_packages(),
     install_requires = [
         "django>=1.7",
-        "python3-ldap==0.9.5.3",
+        "ldap3==0.9.8.2",
     ],
     classifiers = [
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
Old package 'python3_ldap' is now called 'ldap3'. And 'python3_ldap' version 0.9.5.3 is no more available on pypi