### PR TITLE
Changed ldap3 dependency version to >=

### DIFF
--- a/django_python3_ldap/__init__.py
+++ b/django_python3_ldap/__init__.py
@@ -3,4 +3,4 @@ Django LDAP user authentication backend for Python 3.
 """
 
 
-__version__ = (0, 9, 2)
+__version__ = (0, 9, 3)

--- a/django_python3_ldap/__init__.py
+++ b/django_python3_ldap/__init__.py
@@ -3,4 +3,4 @@ Django LDAP user authentication backend for Python 3.
 """
 
 
-__version__ = (0, 9, 3)
+__version__ = (0, 9, 4)

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     packages = find_packages(),
     install_requires = [
         "django>=1.7",
-        "ldap3==0.9.8.2",
+        "ldap3>=0.9.8.4",
     ],
     classifiers = [
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
It appears that the ldap3 project removes older revisions from pypi as
new ones are released, eventually breaking the == version.
This will allow the current version to be pulled.