### PR TITLE
Implemented hook for full saving override

### DIFF
--- a/django_python3_ldap/ldap.py
+++ b/django_python3_ldap/ldap.py
@@ -41,6 +41,9 @@ class Connection(object):
             for field_name, attribute_name
             in settings.LDAP_AUTH_USER_FIELDS.items()
         }
+        if hasattr(User, 'ldap_auth_mod_hook'):
+            return User.ldap_auth_mod_hook(user_fields)
+
         user_data = settings.LDAP_AUTH_CLEAN_USER_DATA(user_fields)
         # Create the user lookup.
         user_lookup = {


### PR DESCRIPTION
The idea is that the used User model can provide a classmethod to fully override get_or_update logic.

The use case I have is that I want to actually do the update of user data from another source than LDAP. Also, this allows doing different things when first time saving the user vs when updating the user.

BTW it seems the return value of settings.LDAP_AUTH_CLEAN_USER_DATA(user_fields) is never used. In-place editing of user_fields does work, but if that is the intended way, then the clean method should not return anything.