### PR TITLE
Added settings for non-anonymous user syncing to be allowed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 django-python3-ldap changelog
 =============================
 
+0.9.6
+-----
+
+- Added settings option for a username and password to be specified incase anonymous user queries are not allowed
+
 
 0.9.5
 -----

--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,11 @@ Available settings
 
     # The LDAP class that represents a user.
     LDAP_AUTH_OBJECT_CLASS = "inetOrgPerson"
+    
+    # The LDAP Username and password of a user so ldap_sync_users can be run
+    # Set to None if you allow anonymous queries
+    LDAP_AUTH_CONNECTION_USERNAME = None
+    LDAP_AUTH_CONNECTION_PASSWORD = None
 
     # User model fields mapped to the LDAP
     # attributes that represent them.
@@ -75,7 +80,7 @@ the advantage of allowing you to assign permissions and groups to the existing u
 admin interface.
 
 Running ``ldap_sync_users`` as a background cron task is another optional way to
-keep all users in sync on a regular basis. 
+keep all users in sync on a regular basis.
 
 
 Support and announcements
@@ -84,13 +89,13 @@ Support and announcements
 Downloads and bug tracking can be found at the `main project
 website <http://github.com/etianen/django-python3-ldap>`_.
 
-    
+
 More information
 ----------------
 
 The django-python3-ldap project was developed by Dave Hall. You can get the code
 from the `django-python3-ldap project site <http://github.com/etianen/django-python3-ldap>`_.
-    
+
 Dave Hall is a freelance web developer, based in Cambridge, UK. You can usually
 find him on the Internet in a number of different places:
 

--- a/django_python3_ldap/conf.py
+++ b/django_python3_ldap/conf.py
@@ -98,5 +98,17 @@ class LazySettings():
         default = "",
     )
 
+    # A username to perform ldap_sync_users
+    LDAP_AUTH_CONNECTION_USERNAME = LazySetting(
+        name = "LDAP_AUTH_CONNECTION_USERNAME",
+        default = None,
+    )
+
+    # A password to perform ldap_sync_users
+    LDAP_AUTH_CONNECTION_PASSWORD = LazySetting(
+        name = "LDAP_AUTH_CONNECTION_PASSWORD",
+        default = None,
+    )
+
 
 settings = LazySettings(settings)

--- a/django_python3_ldap/ldap.py
+++ b/django_python3_ldap/ldap.py
@@ -141,8 +141,8 @@ def connection(*args, **kwargs):
             search_base = settings.LDAP_AUTH_SEARCH_BASE,
         )
     else:
-        password = None
-        username_dn = None
+        username_dn = settings.LDAP_AUTH_CONNECTION_USERNAME
+        password = settings.LDAP_AUTH_CONNECTION_PASSWORD
     # Make the connection.
     if user_identifier:
         if settings.LDAP_AUTH_USE_TLS:


### PR DESCRIPTION
Prior to this, it was assumed that anonymous queries were allowed to get users when using ```python manage.py ldap_sync_users``` but now I have added the options to be set inside settings.py as follows for those who do not let anonymous queries to work

```python
# The LDAP Username and password of a user so ldap_sync_users can be run
# Set to None if you allow anonymous queries
LDAP_AUTH_CONNECTION_USERNAME = None
LDAP_AUTH_CONNECTION_PASSWORD = None
```