### PR TITLE
1. add ldap data to user object after sync, 2. fix clean_ldap_name regexp

### DIFF
--- a/django_python3_ldap/ldap.py
+++ b/django_python3_ldap/ldap.py
@@ -53,6 +53,8 @@ class Connection(object):
             defaults = user_fields,
             **user_lookup
         )
+        # save ldap attributes for backend
+        setattr(user, 'ldap_data', user_data)
         # All done!
         return user
 
@@ -105,7 +107,7 @@ class Connection(object):
             search_base = settings.LDAP_AUTH_SEARCH_BASE,
             search_filter = search_filter,
             search_scope = ldap3.SEARCH_SCOPE_WHOLE_SUBTREE,
-            attributes = list(settings.LDAP_AUTH_USER_FIELDS.values()),
+            attributes = ldap3.ALL_ATTRIBUTES,
             size_limit = 1,
         ):
             return self._get_or_create_user(self._connection.response[0])

--- a/django_python3_ldap/utils.py
+++ b/django_python3_ldap/utils.py
@@ -17,7 +17,7 @@ def clean_ldap_name(name):
     # values, but I can't find the documentation anywhere!
     # This just removes bad characters entirely, which will
     # work for most cases, but isn't exactly ideal! :O
-    return re.sub("[^a-zA-Z0-9_\-]", "", force_text(name))
+    return re.sub("[^a-zA-Z0-9_\-.]", "", force_text(name))
 
 
 def clean_user_data(user_data):


### PR DESCRIPTION
1. add ldap data to user object after sync
feature usage example:

``` py
from django_python3_ldap.auth import LDAPBackend
class MyLDAPBackend(LDAPBackend):
    def authenticate(self, username, password, **kwargs):
        user = super(MyLDAPBackend, self).authenticate(username, password, **kwargs)
		# do something with ldap_data...
        display_name = user.ldap_data['attributes'].get('displayName', (None,))[0]
        return user
```

2. fix clean_ldap_name regexp
Added a dot character