### PR TITLE
add LDAP_AUTH_SYNC_USER_RELATIONS setting

### DIFF
--- a/django_python3_ldap/conf.py
+++ b/django_python3_ldap/conf.py
@@ -4,7 +4,7 @@ Settings used by django-python3.
 
 from django.conf import settings
 
-from django_python3_ldap.utils import clean_user_data
+from django_python3_ldap.utils import clean_user_data, sync_user_relations
 
 
 class LazySetting():
@@ -84,6 +84,11 @@ class LazySettings():
     LDAP_AUTH_CLEAN_USER_DATA = LazySetting(
         name = "LDAP_AUTH_CLEAN_USER_DATA",
         default = clean_user_data,
+    )
+
+    LDAP_AUTH_SYNC_USER_RELATIONS = LazySetting(
+        name = "LDAP_AUTH_SYNC_USER_RELATIONS",
+        default = sync_user_relations
     )
 
     # A username to use when running the live LDAP tests.

--- a/django_python3_ldap/ldap.py
+++ b/django_python3_ldap/ldap.py
@@ -53,6 +53,9 @@ class Connection(object):
             defaults = user_fields,
             **user_lookup
         )
+        # Update relations
+        settings.LDAP_AUTH_SYNC_USER_RELATIONS(user, attributes)
+
         # All done!
         return user
 
@@ -105,7 +108,7 @@ class Connection(object):
             search_base = settings.LDAP_AUTH_SEARCH_BASE,
             search_filter = search_filter,
             search_scope = ldap3.SEARCH_SCOPE_WHOLE_SUBTREE,
-            attributes = list(settings.LDAP_AUTH_USER_FIELDS.values()),
+            attributes = ldap3.ALL_ATTRIBUTES,
             size_limit = 1,
         ):
             return self._get_or_create_user(self._connection.response[0])

--- a/django_python3_ldap/utils.py
+++ b/django_python3_ldap/utils.py
@@ -30,6 +30,11 @@ def clean_user_data(user_data):
     return user_data
 
 
+def sync_user_relations(user, ldap_data):
+    # do nothing by default
+    return ldap_data
+
+
 def resolve_user_identifier(lookup_fields, required, args, kwargs):
     """
     Resolves a user identifier from the given args


### PR DESCRIPTION
 to have a possibility to store additional ldap-data in database.

Created from maintainer recommendations in the comment of #14 PullRequest.