### PR TITLE
Added LDAP_AUTH_USE_SSL setting.

### DIFF
--- a/django_python3_ldap/conf.py
+++ b/django_python3_ldap/conf.py
@@ -47,6 +47,12 @@ class LazySettings():
         default = False,
     )
 
+    # Initiate SSL on connection.
+    LDAP_AUTH_USE_SSL = LazySetting(
+        name = "LDAP_AUTH_USE_SSL",
+        default = False,
+    )
+
     # The LDAP search base for looking up users.
     LDAP_AUTH_SEARCH_BASE = LazySetting(
         name = "LDAP_AUTH_SEARCH_BASE",

--- a/django_python3_ldap/ldap.py
+++ b/django_python3_ldap/ldap.py
@@ -155,7 +155,7 @@ def connection(*args, **kwargs):
     else:
         auto_bind = ldap3.AUTO_BIND_NONE
     try:
-        with ldap3.Connection(ldap3.Server(settings.LDAP_AUTH_URL), user=username_dn, password=password, auto_bind=auto_bind) as c:
+        with ldap3.Connection(ldap3.Server(settings.LDAP_AUTH_URL, use_ssl=settings.LDAP_AUTH_USE_SSL), user=username_dn, password=password, auto_bind=auto_bind) as c:
             yield Connection(c)
     except (ldap3.LDAPBindError, ldap3.LDAPSASLPrepError):
         yield None


### PR DESCRIPTION
I've got to integrate with a server that won't let me connect unless use_ssl=True.

So I added this setting.

What do you think?