### PR TITLE
Python2.7 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ docs/_build
 *.sqlite3
 .coverage
 *.egg-info
+.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 sudo: false
 python:
+  - 2.7
   - 3.2
   - 3.3
   - 3.4
@@ -25,7 +26,7 @@ cache:
 install:
   - travis_retry pip install $DJANGO coverage --download-cache $HOME/.pip-cache
   - pip install -e . --download-cache $HOME/.pip-cache
-script: 
+script:
   - coverage run tests/manage.py test django_python3_ldap
 after_script:
   - coverage report

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ cache:
   directories:
     - $HOME/.pip-cache/
 install:
-  - travis_retry pip install $DJANGO coverage --download-cache $HOME/.pip-cache
+  - travis_retry pip install $DJANGO "coverage<4.0" --download-cache $HOME/.pip-cache
   - pip install -e . --download-cache $HOME/.pip-cache
 script:
   - coverage run tests/manage.py test django_python3_ldap

--- a/django_python3_ldap/conf.py
+++ b/django_python3_ldap/conf.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django_python3_ldap.utils import clean_user_data, sync_user_relations
 
 
-class LazySetting():
+class LazySetting(object):
 
     """
     A proxy to a named Django setting.
@@ -23,7 +23,7 @@ class LazySetting():
         return getattr(obj._settings, self.name, self.default)
 
 
-class LazySettings():
+class LazySettings(object):
 
     """
     A proxy to ldap-specific django settings.

--- a/django_python3_ldap/tests.py
+++ b/django_python3_ldap/tests.py
@@ -4,13 +4,12 @@ from __future__ import unicode_literals
 from unittest import skipUnless
 from io import StringIO, BytesIO
 
-import six
-
 from django.test import TestCase
 from django.contrib.auth import authenticate
 from django.contrib.auth.models import User
 from django.conf import settings as django_settings
 from django.core.management import call_command, CommandError
+from django.utils import six
 
 from django_python3_ldap.conf import settings
 from django_python3_ldap.ldap import connection

--- a/django_python3_ldap/utils.py
+++ b/django_python3_ldap/utils.py
@@ -3,11 +3,11 @@ Some useful LDAP utilities.
 """
 
 import re, binascii
-import six
 
 from django.contrib.auth.hashers import make_password
 from django.utils.encoding import force_text
 from django.utils.module_loading import import_string
+from django.utils import six
 
 
 def clean_ldap_name(name):

--- a/django_python3_ldap/utils.py
+++ b/django_python3_ldap/utils.py
@@ -3,6 +3,7 @@ Some useful LDAP utilities.
 """
 
 import re, binascii
+import six
 
 from django.contrib.auth.hashers import make_password
 from django.utils.encoding import force_text
@@ -72,6 +73,6 @@ def import_func(func):
     """
     if callable(func):
         return func
-    elif isinstance(func, str):
+    elif isinstance(func, six.string_types):
         return import_string(func)
     raise AttributeError("It's not a function {0!r}".format(func))

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ setup(
     install_requires = [
         "django>=1.7",
         "ldap3>=0.9.8.4",
-        "six",
     ],
     classifiers = [
         "Development Status :: 4 - Beta",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from django_python3_ldap import __version__
 
 
 version_str = ".".join(str(n) for n in __version__)
-        
+
 
 setup(
     name = "django-python3-ldap",
@@ -18,6 +18,7 @@ setup(
     install_requires = [
         "django>=1.7",
         "ldap3>=0.9.8.4",
+        "six",
     ],
     classifiers = [
         "Development Status :: 4 - Beta",
@@ -26,6 +27,7 @@ setup(
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
+        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.2",
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,27 @@
+# Tox (http://codespeak.net/~hpk/tox/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+minversion=1.8.0
+envlist =
+    py27-django17,
+    py27-django18,
+
+    py32-django17,
+    py32-django18,
+
+    py33-django17,
+    py33-django18,
+
+    py34-django17,
+    py34-django18,
+
+[testenv]
+changedir = tests
+commands = python manage.py test django_python3_ldap
+deps =
+    django17: django >=1.7,<1.8
+    django18: django >=1.8,<1.9
+passenv = LDAP_AUTH_*


### PR DESCRIPTION
* fix the few code incompatibilities with six
* add tox to test locally with various python versions

Fix for #23 

tox is callable with :
```sh
LDAP_AUTH_URL=ldap://localhost LDAP_AUTH_SEARCH_BASE=dc=example,dc=com
LDAP_AUTH_TEST_USER_USERNAME=test_user
LDAP_AUTH_TEST_USER_PASSWORD=test_password tox
```