### PR TITLE
Add setting for extra LDAP search filter for custom filtering of users

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,9 @@ Available settings
     # The LDAP class that represents a user.
     LDAP_AUTH_OBJECT_CLASS = "inetOrgPerson"
 
+    # Extra LDAP search filter for matching users.
+    LDAP_AUTH_SEARCH_EXTRA_FILTER = ""
+
     # The LDAP Username and password of a user so ldap_sync_users can be run
     # Set to None if you allow anonymous queries
     LDAP_AUTH_CONNECTION_USERNAME = None

--- a/django_python3_ldap/conf.py
+++ b/django_python3_ldap/conf.py
@@ -59,6 +59,12 @@ class LazySettings(object):
         default = "inetOrgPerson",
     )
 
+    # Extra search filter for matching users.
+    LDAP_AUTH_SEARCH_EXTRA_FILTER = LazySetting(
+        name = "LDAP_AUTH_SEARCH_EXTRA_FILTER",
+        default = "",
+    )
+
     # User model fields mapped to the LDAP
     # attributes that represent them.
     LDAP_AUTH_USER_FIELDS = LazySetting(

--- a/django_python3_ldap/ldap.py
+++ b/django_python3_ldap/ldap.py
@@ -93,7 +93,7 @@ class Connection(object):
         # Parse the user lookup.
         user_identifier = resolve_user_identifier(settings.LDAP_AUTH_USER_LOOKUP_FIELDS, True, args, kwargs)
         # Search the LDAP database.
-        search_filter = "(&(objectClass={object_class}){user_identifier})".format(
+        search_filter = "(&(objectClass={object_class}){user_identifier}{extra_filter})".format(
             object_class = clean_ldap_name(settings.LDAP_AUTH_OBJECT_CLASS),
             user_identifier = "".join(
                 "({attribute_name}={field_value})".format(
@@ -103,12 +103,14 @@ class Connection(object):
                 for field_name, field_value
                 in user_identifier.items()
             ),
+            extra_filter = settings.LDAP_AUTH_SEARCH_EXTRA_FILTER,
         )
         if self._connection.search(
             search_base = settings.LDAP_AUTH_SEARCH_BASE,
             search_filter = search_filter,
             search_scope = ldap3.SEARCH_SCOPE_WHOLE_SUBTREE,
             attributes = ldap3.ALL_ATTRIBUTES,
+            get_operational_attributes = True,
             size_limit = 1,
         ):
             return self._get_or_create_user(self._connection.response[0])


### PR DESCRIPTION
A common use case for this is to have a filter on 'memberOf' overlay
attribute, so as to match only users that are member of specific groups
in LDAP.