### PR TITLE
Include operational attributes in LDAP search results

### DIFF
--- a/django_python3_ldap/ldap.py
+++ b/django_python3_ldap/ldap.py
@@ -89,6 +89,7 @@ class Connection(object):
             search_filter = format_search_filter(kwargs),
             search_scope = ldap3.SEARCH_SCOPE_WHOLE_SUBTREE,
             attributes = ldap3.ALL_ATTRIBUTES,
+            get_operational_attributes = True,
             size_limit = 1,
         ):
             return self._get_or_create_user(self._connection.response[0])

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     packages = find_packages(),
     install_requires = [
         "django>=1.7",
-        "ldap3>=0.9.8.4",
+        "ldap3>=0.9.8.4,!=0.9.9.2",
     ],
     classifiers = [
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
This allows filtering users based on [operational attributes][1].

A good example of an operational attribute is the "memberOf" attribute in OpenLDAP setups.
While some LDAP servers may return this particular attribute as a normal, user attribute,
OpenLDAP configured with the memberof overlay considers it an operational attribute and
will return it only if that is asked explicitly.

Note: ldap3 library in version 0.9.9.2 introduced a bug when both `attributes=ALL_ATTRIBUTES` and
`get_operational_attributes=True` are used in search that makes search results include only the
operational attributes, so we exclude it from the requirements. This bug has been fixed for next
release.

[1]: https://tools.ietf.org/html/rfc4512#section-3.4