### PR TITLE
Allow ':' in LDAP attribute names

### DIFF
--- a/django_python3_ldap/utils.py
+++ b/django_python3_ldap/utils.py
@@ -25,7 +25,7 @@ def clean_ldap_name(name):
     Transforms the given name into a form that
     won't interfere with LDAP queries.
     """
-    return re.sub(r'[^a-zA-Z0-9 _\-.@]', lambda c: "\\" + force_text(binascii.hexlify(c.group(0).encode("latin-1", errors="ignore"))).upper(), force_text(name))
+    return re.sub(r'[^a-zA-Z0-9 _\-.@:]', lambda c: "\\" + force_text(binascii.hexlify(c.group(0).encode("latin-1", errors="ignore"))).upper(), force_text(name))
 
 
 def convert_model_fields_to_ldap_fields(model_fields):

--- a/django_python3_ldap/utils.py
+++ b/django_python3_ldap/utils.py
@@ -25,7 +25,7 @@ def clean_ldap_name(name):
     Transforms the given name into a form that
     won't interfere with LDAP queries.
     """
-    return re.sub(r'[^a-zA-Z0-9 _\-.@:]', lambda c: "\\" + force_text(binascii.hexlify(c.group(0).encode("latin-1", errors="ignore"))).upper(), force_text(name))
+    return re.sub(r'[^a-zA-Z0-9 _\-.@:*]', lambda c: "\\" + force_text(binascii.hexlify(c.group(0).encode("latin-1", errors="ignore"))).upper(), force_text(name))
 
 
 def convert_model_fields_to_ldap_fields(model_fields):


### PR DESCRIPTION
This allows using : in LDAP attribute names, so I could have a custom format search filter like memberOf:1.2.840.113556.1.4.1941: which will recursively search groups in Active Directory.