### PR TITLE
Fixing Django 1.10 warnings and enable ldap attributes for iter_users

### DIFF
--- a/django_python3_ldap/ldap.py
+++ b/django_python3_ldap/ldap.py
@@ -68,6 +68,7 @@ class Connection(object):
             search_filter = format_search_filter({}),
             search_scope = ldap3.SEARCH_SCOPE_WHOLE_SUBTREE,
             attributes = ldap3.ALL_ATTRIBUTES,
+            get_operational_attributes = True,
             paged_size = 30,
         )
         return (

--- a/django_python3_ldap/management/commands/ldap_sync_users.py
+++ b/django_python3_ldap/management/commands/ldap_sync_users.py
@@ -1,16 +1,16 @@
-from django.core.management.base import NoArgsCommand
+from django.core.management.base import BaseCommand
 from django.db import transaction
 
 from django_python3_ldap import ldap
 from django_python3_ldap.conf import settings
 
 
-class Command(NoArgsCommand):
+class Command(BaseCommand):
 
     help = "Creates local user models for all users found in the remote LDAP authentication server."
 
     @transaction.atomic()
-    def handle_noargs(self, **kwargs):
+    def handle(self, *args, **kwargs):
         verbosity = int(kwargs.get("verbosity", 1))
         with ldap.connection(username=settings.LDAP_AUTH_CONNECTION_USERNAME, password=settings.LDAP_AUTH_CONNECTION_PASSWORD) as connection:
             for user in connection.iter_users():


### PR DESCRIPTION
Replace NoArgsCommand as it is deprecated as of Django 1.10.

```
./manage.py ldap_sync_users
/home/robbie/work/nmap_tool/venv/lib/python3.4/site-packages/django/core/management/base.py:577: RemovedInDjango110Warning: NoArgsCommand class is deprec
ated and will be removed in Django 1.10. Use BaseCommand instead, which takes no arguments by default.
  RemovedInDjango110Warning
```

I took the directly from a commit made to your watson repository.. :-)