### PR TITLE
[WIP] - Patch 1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@ django-python3-ldap changelog
 =============================
 
 
+0.9.11
+------
+
+- LDAP_AUTH_CONNECTION_USERNAME and LDAP_AUTH_CONNECTION_PASSWORD settings have been replaced by a dictionary LDAP_AUTH_CONNECTION_KWARGS to allow ``ldap_sync_user`` command to work with ``User`` models that have their ``username`` or ``password`` field labeled differently e.g. ``email`` and ``pass`` (@audiolion)
+- tox.ini updated to test against Django 1.9 and 1.10 explicitly, added python35 tests to django >=1.8 supporting 3.5 (@audiolion)
+
+
 0.9.10
 ------
 

--- a/README.rst
+++ b/README.rst
@@ -81,9 +81,13 @@ Available settings
     LDAP_AUTH_ACTIVE_DIRECTORY_DOMAIN = None
 
     # The LDAP username and password of a user for authenticating the `ldap_sync_users`
-    # management command. Set to None if you allow anonymous queries.
-    LDAP_AUTH_CONNECTION_USERNAME = None
-    LDAP_AUTH_CONNECTION_PASSWORD = None
+    # management command. If the User model has a different label for `username` or
+    # `password`, modify the keys to the appropriate labels. Values can be set to None
+    # if you allow anonymous queries.
+    LDAP_AUTH_CONNECTION_KWARGS = {
+    	"username": None
+    	"password": None
+    }
 
 
 Microsoft Active Directory support

--- a/django_python3_ldap/conf.py
+++ b/django_python3_ldap/conf.py
@@ -105,14 +105,12 @@ class LazySettings(object):
         default = "",
     )
 
-    LDAP_AUTH_CONNECTION_USERNAME = LazySetting(
-        name = "LDAP_AUTH_CONNECTION_USERNAME",
-        default = None,
-    )
-
-    LDAP_AUTH_CONNECTION_PASSWORD = LazySetting(
-        name = "LDAP_AUTH_CONNECTION_PASSWORD",
-        default = None,
+    LDAP_AUTH_CONNECTION_KWARGS = LazySetting(
+        name = "LDAP_AUTH_CONNECT_KWARGS",
+        default = {
+            "username": None,
+            "password": None,
+        },
     )
 
 

--- a/django_python3_ldap/management/commands/ldap_sync_users.py
+++ b/django_python3_ldap/management/commands/ldap_sync_users.py
@@ -12,7 +12,7 @@ class Command(BaseCommand):
     @transaction.atomic()
     def handle(self, *args, **kwargs):
         verbosity = int(kwargs.get("verbosity", 1))
-        with ldap.connection(username=settings.LDAP_AUTH_CONNECTION_USERNAME, password=settings.LDAP_AUTH_CONNECTION_PASSWORD) as connection:
+        with ldap.connection(**settings.LDAP_AUTH_CONNECTION_KWARGS) as connection:
             for user in connection.iter_users():
                 if verbosity >= 1:
                     self.stdout.write("Synced {user}".format(

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,8 @@ minversion=1.8.0
 envlist =
     py27-django17,
     py27-django18,
+    py27-django19,
+    py27-django110,
 
     py32-django17,
     py32-django18,
@@ -17,6 +19,12 @@ envlist =
 
     py34-django17,
     py34-django18,
+    py34-django19,
+    py34-django110,
+
+    py35-django18,
+    py35-django19,
+    py35-django110,
 
 [testenv]
 changedir = tests
@@ -24,4 +32,6 @@ commands = python manage.py test django_python3_ldap
 deps =
     django17: django >=1.7,<1.8
     django18: django >=1.8,<1.9
+    django19: django >=1.9,<1.10
+    django110: django ==1.10b1
 passenv = LDAP_AUTH_*


### PR DESCRIPTION
References #45 

How should we handle the switch that breaks backwards compatibility? I know you said to not worry about deprecation warnings for the maintenance cost. Currently if people are using the `LDAP_AUTH_CONNECTION_USERNAME` or `LDAP_AUTH_CONNECTION_PASSWORD` settings the program will still work if anonymous binds are allowed with potential changes in behavior due to restrictions. Should we then include a warning if we see these settings set or a hard stop? The update is relatively painless, just moving the credentials into the dictionary values.

I also updated the tox.ini, are those changes ok?

I want to just add a couple tests and get any feedback for I finish this.
