### PR TITLE
Fixed issue where a non-existent group with an existent user would cause a KeyError

### DIFF
--- a/django_python3_ldap/__init__.py
+++ b/django_python3_ldap/__init__.py
@@ -3,4 +3,4 @@ Django LDAP user authentication backend for Python 3.
 """
 
 
-__version__ = (0, 9, 10)
+__version__ = (0, 9, 11)

--- a/django_python3_ldap/ldap.py
+++ b/django_python3_ldap/ldap.py
@@ -38,7 +38,11 @@ class Connection(object):
         If the user does not exist, then it will be created.
         """
         User = get_user_model()
-        attributes = user_data["attributes"]
+
+        attributes = user_data.get("attributes")
+        if attributes is None:
+            return None
+
         # Create the user data.
         user_fields = {
             field_name: attributes.get(attribute_name, ("",))[0]

--- a/django_python3_ldap/ldap.py
+++ b/django_python3_ldap/ldap.py
@@ -37,11 +37,12 @@ class Connection(object):
 
         If the user does not exist, then it will be created.
         """
-        User = get_user_model()
 
         attributes = user_data.get("attributes")
         if attributes is None:
             return None
+
+        User = get_user_model()
 
         # Create the user data.
         user_fields = {
@@ -79,12 +80,12 @@ class Connection(object):
             get_operational_attributes = True,
             paged_size = 30,
         )
-        return (
+        return filter(None, (
             self._get_or_create_user(entry)
             for entry
             in paged_entries
             if entry["type"] == "searchResEntry"
-        )
+        ))
 
     def get_user(self, **kwargs):
         """

--- a/django_python3_ldap/tests.py
+++ b/django_python3_ldap/tests.py
@@ -103,7 +103,7 @@ class TestLdap(TestCase):
             self.assertIsInstance(user, User)
             self.assertEqual(user.username, settings.LDAP_AUTH_TEST_USER_USERNAME)
 
-    # User syncronisation.
+    # User synchronisation.
 
     def testSyncUsersCreatesUsers(self):
         call_command("ldap_sync_users", verbosity=0)

--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,12 @@
 # and then run "tox" from this directory.
 
 [tox]
-minversion=1.8.0
+minversion=1.8
 envlist =
     py27-django17,
     py27-django18,
+    py27-django19,
+    py27-django110,
 
     py32-django17,
     py32-django18,
@@ -17,6 +19,8 @@ envlist =
 
     py34-django17,
     py34-django18,
+    py34-django19,
+    py34-django110,
 
 [testenv]
 changedir = tests
@@ -24,4 +28,6 @@ commands = python manage.py test django_python3_ldap
 deps =
     django17: django >=1.7,<1.8
     django18: django >=1.8,<1.9
+    django19: django >=1.9,<1.10
+    django110: django >=1.10,<1.11
 passenv = LDAP_AUTH_*

--- a/tox.ini
+++ b/tox.ini
@@ -6,12 +6,10 @@
 [tox]
 minversion=1.8
 envlist =
-    py27-django17,
     py27-django18,
     py27-django19,
     py27-django110,
 
-    py34-django17,
     py34-django18,
     py34-django19,
     py34-django110,
@@ -20,7 +18,6 @@ envlist =
 changedir = tests
 commands = python manage.py test django_python3_ldap
 deps =
-    django17: django >=1.7,<1.8
     django18: django >=1.8,<1.9
     django19: django >=1.9,<1.10
     django110: django >=1.10,<1.11

--- a/tox.ini
+++ b/tox.ini
@@ -11,12 +11,6 @@ envlist =
     py27-django19,
     py27-django110,
 
-    py32-django17,
-    py32-django18,
-
-    py33-django17,
-    py33-django18,
-
     py34-django17,
     py34-django18,
     py34-django19,


### PR DESCRIPTION
...for Active Directory due to missing attributes if a valid user but invalid group was specified. Added test procedures for Django 1.9 and 1.10 with Python 2.7 and 3.4.
