### PR TITLE
Allow "=" in ldap field values

### DIFF
--- a/django_python3_ldap/utils.py
+++ b/django_python3_ldap/utils.py
@@ -26,7 +26,7 @@ def clean_ldap_name(name):
     won't interfere with LDAP queries.
     """
     return re.sub(
-        r'[^a-zA-Z0-9 _\-.@]',
+        r'[^a-zA-Z0-9 _\-=.@]',
         lambda c: "\\" + force_text(binascii.hexlify(c.group(0).encode("latin-1", errors="ignore"))).upper(),
         force_text(name),
     )


### PR DESCRIPTION
Allows custom format search filters to use:  ldap_fields["memberOf"] = "CN=mygroup,CN=Users,DC=mydomain,DC=com"