### PR TITLE
Feature/support custom django user model

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 django-python3-ldap changelog
 =============================
 
+0.11.0
+------
+
+- Support added for User models with a ``USERNAME_FIELD`` other than ``username`` (@audiolion)
+
+
 0.10.0
 ------
 

--- a/django_python3_ldap/ldap.py
+++ b/django_python3_ldap/ldap.py
@@ -167,9 +167,10 @@ def connection(**kwargs):
             settings.LDAP_AUTH_CONNECTION_PASSWORD != password
         )
     ):
+        User = get_user_model()
         try:
             c.rebind(
-                user=format_username({"username": settings.LDAP_AUTH_CONNECTION_USERNAME}),
+                user=format_username({User.USERNAME_FIELD: settings.LDAP_AUTH_CONNECTION_USERNAME}),
                 password=settings.LDAP_AUTH_CONNECTION_PASSWORD,
             )
         except LDAPException as ex:

--- a/django_python3_ldap/management/commands/ldap_sync_users.py
+++ b/django_python3_ldap/management/commands/ldap_sync_users.py
@@ -1,3 +1,4 @@
+from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 
@@ -12,10 +13,12 @@ class Command(BaseCommand):
     @transaction.atomic()
     def handle(self, *args, **kwargs):
         verbosity = int(kwargs.get("verbosity", 1))
-        with ldap.connection(
-            username=settings.LDAP_AUTH_CONNECTION_USERNAME,
-            password=settings.LDAP_AUTH_CONNECTION_PASSWORD,
-        ) as connection:
+        User = get_user_model()
+        auth_kwargs = {
+            User.USERNAME_FIELD: settings.LDAP_AUTH_CONNECTION_USERNAME,
+            password: settings.LDAP_AUTH_CONNECTION_PASSWORD
+        }
+        with ldap.connection(**auth_kwargs) as connection:
             if connection is None:
                 raise CommandError("Could not connect to LDAP server")
             for user in connection.iter_users():

--- a/django_python3_ldap/management/commands/ldap_sync_users.py
+++ b/django_python3_ldap/management/commands/ldap_sync_users.py
@@ -16,7 +16,7 @@ class Command(BaseCommand):
         User = get_user_model()
         auth_kwargs = {
             User.USERNAME_FIELD: settings.LDAP_AUTH_CONNECTION_USERNAME,
-            password: settings.LDAP_AUTH_CONNECTION_PASSWORD
+            'password': settings.LDAP_AUTH_CONNECTION_PASSWORD
         }
         with ldap.connection(**auth_kwargs) as connection:
             if connection is None:


### PR DESCRIPTION
Resolves #45 

Much simpler solution than my previous PR, using the [USERNAME_FIELD](https://docs.djangoproject.com/en/1.8/topics/auth/customizing/#django.contrib.auth.models.CustomUser.USERNAME_FIELD) identifier on the `User` model to support identifiers other than `username`.

I didn't want to overreach but using this field you could probably eliminate the `LDAP_AUTH_LOOKUP_FIELDS` setting and just lookup based on the `USERNAME_FIELD`. This defaults to `username` for the regular `django.contrib.auth.models.User`