### PR TITLE
Add timeouts kwargs on Server/Connection construction

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,6 +86,10 @@ Available settings
     LDAP_AUTH_CONNECTION_USERNAME = None
     LDAP_AUTH_CONNECTION_PASSWORD = None
 
+    # Set connection/receive timeouts (in seconds) on the underlying `ldap3` library.
+    LDAP_AUTH_CONNECT_TIMEOUT = None
+    LDAP_AUTH_RECEIVE_TIMEOUT = None
+
 
 Microsoft Active Directory support
 ----------------------------------

--- a/django_python3_ldap/conf.py
+++ b/django_python3_ldap/conf.py
@@ -115,5 +115,15 @@ class LazySettings(object):
         default=None,
     )
 
+    LDAP_AUTH_CONNECT_TIMEOUT = LazySetting(
+        name="LDAP_AUTH_CONNECT_TIMEOUT",
+        default=None
+    )
+
+    LDAP_AUTH_RECEIVE_TIMEOUT = LazySetting(
+        name="LDAP_AUTH_RECEIVE_TIMEOUT",
+        default=None
+    )
+
 
 settings = LazySettings(settings)

--- a/django_python3_ldap/ldap.py
+++ b/django_python3_ldap/ldap.py
@@ -150,11 +150,13 @@ def connection(**kwargs):
                 settings.LDAP_AUTH_URL,
                 allowed_referral_hosts=[("*", True)],
                 get_info=ldap3.NONE,
+                connect_timeout=settings.LDAP_AUTH_CONNECT_TIMEOUT,
             ),
             user=username,
             password=password,
             auto_bind=auto_bind,
             raise_exceptions=True,
+            receive_timeout=settings.LDAP_AUTH_RECEIVE_TIMEOUT,
         )
     except LDAPException as ex:
         logger.warning("LDAP connect failed: {ex}".format(ex=ex))


### PR DESCRIPTION
If the LDAP server is down or unreachable for any reason, the entire Django app will hang. This adds the ability to set a timeout in `ldap3`, to prevent that from happenning