### PR TITLE
Properly handle duplicate keys

### DIFF
--- a/django_python3_ldap/ldap.py
+++ b/django_python3_ldap/ldap.py
@@ -44,16 +44,14 @@ class Connection(object):
         User = get_user_model()
 
         # Create the user data.
-        user_fields = {
-            field_name: (
-                attributes[attribute_name][0]
-                if isinstance(attributes[attribute_name], (list, tuple)) else
-                attributes[attribute_name]
-            )
-            for field_name, attribute_name
-            in settings.LDAP_AUTH_USER_FIELDS.items()
-            if attribute_name in attributes
-        }
+        user_fields = dict()
+        for field_name, attribute_name in settings.LDAP_AUTH_USER_FIELDS.items():
+            if attribute_name not in attributes:
+                continue
+            value = attributes[attribute_name]
+            value_list = list(value) if isinstance(value, (list, tuple)) else [value]
+            user_fields[field_name] = value_list[0]
+            user_fields[field_name + '__list'] = value_list
         user_fields = import_func(settings.LDAP_AUTH_CLEAN_USER_DATA)(user_fields)
         # Create the user lookup.
         user_lookup = {


### PR DESCRIPTION
See issue #135.

This extends the `User` object by additional attributes that allow proper handling of LDAP and its multiple values for a single key (or duplicate keys, depending on how you look at it).

Added benefit: This could be used as a temporary workaround until #103 lands.

I couldn't properly test it, but [I tried](https://travis-ci.org/BenWiederhake/django-python3-ldap).  Also, it doesn't crash on instantiation.