### PR TITLE
Add ssl support.

### DIFF
--- a/django_python3_ldap/conf.py
+++ b/django_python3_ldap/conf.py
@@ -43,6 +43,11 @@ class LazySettings(object):
         default=False,
     )
 
+    LDAP_AUTH_USE_SSL = LazySetting(
+        name="LDAP_AUTH_USE_SSL",
+        default=False,
+    )
+
     LDAP_AUTH_SEARCH_BASE = LazySetting(
         name="LDAP_AUTH_SEARCH_BASE",
         default="ou=people,dc=example,dc=com",

--- a/django_python3_ldap/ldap.py
+++ b/django_python3_ldap/ldap.py
@@ -148,6 +148,7 @@ def connection(**kwargs):
         c = ldap3.Connection(
             ldap3.Server(
                 settings.LDAP_AUTH_URL,
+                use_ssl=settings.LDAP_AUTH_USE_SSL,
                 allowed_referral_hosts=[("*", True)],
                 get_info=ldap3.NONE,
                 connect_timeout=settings.LDAP_AUTH_CONNECT_TIMEOUT,


### PR DESCRIPTION
Add the 'use_ssl' parameter to the ldap3.Server constructor.

Add an ssl flag to the config.