### PR TITLE
Use the last version of pyasn1 0.4.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     install_requires=[
         "django>=1.8",
         "ldap3==2.5",
-        "pyasn1==0.4.5",
+        "pyasn1==0.4.6",
     ],
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
Is it possible to have a new release including the new version of pyasn1 ?