### PR TITLE
Fix: cannot import name 'six' from 'django.utils'

### DIFF
--- a/django_python3_ldap/tests.py
+++ b/django_python3_ldap/tests.py
@@ -9,7 +9,7 @@ from django.contrib.auth import authenticate
 from django.contrib.auth.models import User
 from django.conf import settings as django_settings
 from django.core.management import call_command, CommandError
-from django.utils import six
+import six
 
 from django_python3_ldap.conf import settings
 from django_python3_ldap.ldap import connection

--- a/django_python3_ldap/utils.py
+++ b/django_python3_ldap/utils.py
@@ -6,7 +6,7 @@ import re
 import binascii
 from django.utils.encoding import force_text
 from django.utils.module_loading import import_string
-from django.utils import six
+import six
 
 from django_python3_ldap.conf import settings
 

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
         "django>=1.8",
         "ldap3>=2.5,<3",
         "pyasn1>=0.4.6,<0.5",
+        "six>=1.0",
     ],
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
fixes https://github.com/django-auth-ldap/django-auth-ldap/issues/162