### PR TITLE
Pass connection object to LDAP_AUTH_SYNC_USER_RELATIONS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -132,6 +132,30 @@ better than the defaults used by django-python3-ldap:
     LDAP_AUTH_OBJECT_CLASS = "user"
 
 
+Sync User Relations
+-------------------
+
+As part of the user authentication process, django-python3-ldap calls a function specified by the
+LDAP_AUTH_SYNC_USER_RELATIONS configuraton item.  This function can be used for making additional
+updates to the user database (for example updaing the groups the user is a member of), or getting
+further information from the LDAP server.
+
+The signature of the called function is:-
+
+.. code:: python
+
+    def sync_user_relations(user, ldap_attributes, *, connection=None, dn=None):
+
+In versions up to 0.11.4 just two parameters were passed - a Django user model object, and a dict
+of attributes.  Subsequent versions pass additional parameters as keyword only parameters if the
+sync_user_relations support those named parameters.
+
+The additional parameters are:-
+
+- ``connection`` - the LDAP connection object
+- ``dn`` - the DN (Distinguished Name) of the LDAP matched user
+
+
 Can't get authentication to work?
 ---------------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -146,14 +146,12 @@ The signature of the called function is:-
 
     def sync_user_relations(user, ldap_attributes, *, connection=None, dn=None):
 
-In versions up to 0.11.4 just two parameters were passed - a Django user model object, and a dict
-of attributes.  Subsequent versions pass additional parameters as keyword only parameters if the
-sync_user_relations support those named parameters.
+The parameters are:-
 
-The additional parameters are:-
-
-- ``connection`` - the LDAP connection object
-- ``dn`` - the DN (Distinguished Name) of the LDAP matched user
+- ``user`` - a Django user model object
+- ``ldap_attributes`` - a dict of LDAP attributes
+- ``connection`` - the LDAP connection object (optional keyword only parameter)
+- ``dn`` - the DN (Distinguished Name) of the LDAP matched user (optional keyword only parameter)
 
 
 Can't get authentication to work?

--- a/README.rst
+++ b/README.rst
@@ -60,8 +60,9 @@ Available settings
     # Use this to customize how data loaded from LDAP is saved to the User model.
     LDAP_AUTH_CLEAN_USER_DATA = "django_python3_ldap.utils.clean_user_data"
 
-    # Path to a callable that takes a user model and a dict of {ldap_field_name: [value]},
-    # and saves any additional user relationships based on the LDAP data.
+    # Path to a callable that takes a user model, a dict of {ldap_field_name: [value]}
+    # a LDAP connection object (to allow further lookups), and saves any additional
+    # user relationships based on the LDAP data.
     # Use this to customize how data loaded from LDAP is saved to User model relations.
     # For customizing non-related User model fields, use LDAP_AUTH_CLEAN_USER_DATA.
     LDAP_AUTH_SYNC_USER_RELATIONS = "django_python3_ldap.utils.sync_user_relations"

--- a/django_python3_ldap/ldap.py
+++ b/django_python3_ldap/ldap.py
@@ -71,7 +71,7 @@ class Connection(object):
             user.set_unusable_password()
             user.save()
         # Update relations
-        import_func(settings.LDAP_AUTH_SYNC_USER_RELATIONS)(user, attributes)
+        import_func(settings.LDAP_AUTH_SYNC_USER_RELATIONS)(user, attributes, self._connection)
         # All done!
         logger.info("LDAP user lookup succeeded")
         return user

--- a/django_python3_ldap/ldap.py
+++ b/django_python3_ldap/ldap.py
@@ -74,21 +74,16 @@ class Connection(object):
         # Update relations
         sync_user_relations_func = import_func(settings.LDAP_AUTH_SYNC_USER_RELATIONS)
         sync_user_relations_arginfo = getfullargspec(sync_user_relations_func)
-        if len(sync_user_relations_arginfo.kwonlyargs) == 0:
-            # old 2 argument form
-            sync_user_relations_func(user, attributes)
-        else:
-            # newer additional named argument form
-            args = {}
-            for argname in sync_user_relations_arginfo.kwonlyargs:
-                if argname == "connection":
-                    args["connection"]=self._connection
-                elif argname == "dn":
-                    args["dn"]=user_data.get("dn")
-                else:
-                    logger.error(f"Unknown kw argument {argname} in signature for LDAP_AUTH_SYNC_USER_RELATIONS")
-
-            sync_user_relations_func(user, attributes, **args)
+        args = {}  # additional keyword arguments
+        for argname in sync_user_relations_arginfo.kwonlyargs:
+            if argname == "connection":
+                args["connection"]=self._connection
+            elif argname == "dn":
+                args["dn"]=user_data.get("dn")
+            else:
+                logger.error(f"Unknown kw argument {argname} in signature for LDAP_AUTH_SYNC_USER_RELATIONS")
+        # call sync_user_relations_func() with original args plus supported named extras
+        sync_user_relations_func(user, attributes, **args)
         # All done!
         logger.info("LDAP user lookup succeeded")
         return user

--- a/django_python3_ldap/ldap.py
+++ b/django_python3_ldap/ldap.py
@@ -81,7 +81,7 @@ class Connection(object):
             elif argname == "dn":
                 args["dn"]=user_data.get("dn")
             else:
-                logger.error(f"Unknown kw argument {argname} in signature for LDAP_AUTH_SYNC_USER_RELATIONS")
+                raise TypeError(f"Unknown kw argument {argname} in signature for LDAP_AUTH_SYNC_USER_RELATIONS")
         # call sync_user_relations_func() with original args plus supported named extras
         sync_user_relations_func(user, attributes, **args)
         # All done!

--- a/django_python3_ldap/tests.py
+++ b/django_python3_ldap/tests.py
@@ -167,11 +167,35 @@ class TestLdap(TestCase):
             call_command("ldap_promote", "missing_user", verbosity=0)
 
     def testSyncUserRelations(self):
-        def check_sync_user_relation(user, data, connection):
+        def check_sync_user_relation(user, data, *, connection=None, dn=None):
             # id have been created
             self.assertIsNotNone(user.id)
             # connection was passed
             self.assertIsNotNone(connection)
+            # dn was passed
+            self.assertIsNotNone(dn)
+            # model is saved
+            self.assertEqual(user.username, User.objects.get(pk=user.id).username)
+            # save all groups
+            self.assertIn('cn', data)
+            ldap_groups = list(data.get('memberOf', ()))
+            ldap_groups.append('default_group')
+            for group in ldap_groups:
+                user.groups.create(name=group)
+
+        with self.settings(LDAP_AUTH_SYNC_USER_RELATIONS=check_sync_user_relation):
+            user = authenticate(
+                username=settings.LDAP_AUTH_TEST_USER_USERNAME,
+                password=settings.LDAP_AUTH_TEST_USER_PASSWORD,
+            )
+            self.assertIsInstance(user, User)
+            self.assertGreaterEqual(user.groups.count(), 1)
+            self.assertEqual(user.groups.filter(name='default_group').count(), 1)
+
+    def testOldSyncUserRelations(self):
+        def check_sync_user_relation(user, data):
+            # id have been created
+            self.assertIsNotNone(user.id)
             # model is saved
             self.assertEqual(user.username, User.objects.get(pk=user.id).username)
             # save all groups

--- a/django_python3_ldap/tests.py
+++ b/django_python3_ldap/tests.py
@@ -167,9 +167,11 @@ class TestLdap(TestCase):
             call_command("ldap_promote", "missing_user", verbosity=0)
 
     def testSyncUserRelations(self):
-        def check_sync_user_relation(user, data):
+        def check_sync_user_relation(user, data, connection):
             # id have been created
             self.assertIsNotNone(user.id)
+            # connection was passed
+            self.assertIsNotNone(connection)
             # model is saved
             self.assertEqual(user.username, User.objects.get(pk=user.id).username)
             # save all groups

--- a/django_python3_ldap/utils.py
+++ b/django_python3_ldap/utils.py
@@ -107,7 +107,7 @@ def format_username_active_directory_principal(model_fields):
     return username
 
 
-def sync_user_relations(user, ldap_attributes, ldap_connection):
+def sync_user_relations(user, ldap_attributes, *, connection=None, dn=None):
     # do nothing by default
     pass
 

--- a/django_python3_ldap/utils.py
+++ b/django_python3_ldap/utils.py
@@ -107,7 +107,7 @@ def format_username_active_directory_principal(model_fields):
     return username
 
 
-def sync_user_relations(user, ldap_attributes):
+def sync_user_relations(user, ldap_attributes, ldap_connection):
     # do nothing by default
     pass
 


### PR DESCRIPTION
This allows a further query to be done in sync_user_relations() as per issue #207 

The signature of the sync_user_relations() changes to `custom_sync_user_relations(user, ldap_attributes, ldap_connection)`

A sample that performs an additional query to pull all the groups/nested groups and adds them into django user database, would look like the below:-

```python
"""LDAP group expansion code"""
import ldap3
from django.contrib.auth.models import Group

from .settings import LDAP_AUTH_SEARCH_BASE


def custom_sync_user_relations(user, ldap_attributes, ldap_connection):
    # The LDAP connection has the last result attached...
    dn = ldap_connection.response[0].get("dn")

    # Search the LDAP database for nested groups
    if ldap_connection.search(
        search_base=LDAP_AUTH_SEARCH_BASE,
        search_filter=f"(member:1.2.840.113556.1.4.1941:={dn})",
        search_scope=ldap3.SUBTREE,
        dereference_aliases=ldap3.DEREF_NEVER,
        attributes="CN",  # only need the CN
    ):
        # walk the results
        for entry in ldap_connection.entries:
            # get/create each of the groups
            group, created = Group.objects.get_or_create(name=entry.cn)

            # link to group
            user.groups.add(group)
```

This is pretty minimalist.  It also would not handle someone being removed from groups after having logged in whilst in the groups.
