### PR TITLE
Use dependency injection rather than using settings directly.

### DIFF
--- a/django_python3_ldap/auth.py
+++ b/django_python3_ldap/auth.py
@@ -5,6 +5,7 @@ Django authentication backend.
 from django.contrib.auth.backends import ModelBackend
 
 from django_python3_ldap import ldap
+from django_python3_ldap.conf import settings
 
 
 class LDAPBackend(ModelBackend):
@@ -20,4 +21,4 @@ class LDAPBackend(ModelBackend):
     supports_inactive_user = False
 
     def authenticate(self, *args, **kwargs):
-        return ldap.authenticate(*args, **kwargs)
+        return ldap.authenticate(settings, *args, **kwargs)


### PR DESCRIPTION
This will allow for the backend to be re-implemented using parameters
which are not defined in the settings file, but rather instantiated
ad-hoc. This means that it should be possible to create a LDAP model
which contains the relevant information and use it in a multi-tenant
environment.

Does this make sense or am I misunderstanding something fundamental in LDAP or Django?