### PR TITLE
Allow syncing individual users with ldap_sync_users management command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Installation
 2. Add ``'django_python3_ldap'`` to your ``INSTALLED_APPS`` setting.
 3. Set your ``AUTHENTICATION_BACKENDS`` setting to ``("django_python3_ldap.auth.LDAPBackend",)``
 4. Configure the settings for your LDAP server (see Available settings, below).
-5. Optionally, run ``./manage.py ldap_sync_users`` to perform an initial sync of LDAP users.
+5. Optionally, run ``./manage.py ldap_sync_users`` (or ``./manage.py ldap_sync_users <list of user lookups>``) to perform an initial sync of LDAP users.
 6. Optionally, run ``./manage.py ldap_promote <username>`` to grant superuser admin access to a given user.
 
 

--- a/django_python3_ldap/conf.py
+++ b/django_python3_ldap/conf.py
@@ -100,6 +100,11 @@ class LazySettings(object):
         default="",
     )
 
+    LDAP_AUTH_TEST_USER_EMAIL = LazySetting(
+        name="LDAP_AUTH_TEST_USER_EMAIL",
+        default=""
+    )
+
     LDAP_AUTH_TEST_USER_PASSWORD = LazySetting(
         name="LDAP_AUTH_TEST_USER_PASSWORD",
         default="",

--- a/django_python3_ldap/management/commands/ldap_sync_users.py
+++ b/django_python3_ldap/management/commands/ldap_sync_users.py
@@ -4,7 +4,7 @@ from django.db import transaction
 
 from django_python3_ldap import ldap
 from django_python3_ldap.conf import settings
-from django_python3_ldap.utils import chunk_lookup_args
+from django_python3_ldap.utils import group_lookup_args
 
 
 class Command(BaseCommand):
@@ -22,12 +22,16 @@ class Command(BaseCommand):
 
     @staticmethod
     def _iter_synced_users(connection, lookups):
+        """
+        Iterates over synced users. If the list of lookups is empty, then all users are synced using iter_users.
+        However, if lookups are provided, get_user is used to sync each user found using the lookups.
+        """
         if len(lookups) < 1:
             for user in connection.iter_users():
                 yield user
         else:
-            for chunk in chunk_lookup_args(*lookups):
-                yield connection.get_user(**chunk)
+            for lookup in group_lookup_args(*lookups):
+                yield connection.get_user(**lookup)
 
     @transaction.atomic()
     def handle(self, *args, **kwargs):

--- a/django_python3_ldap/management/commands/ldap_sync_users.py
+++ b/django_python3_ldap/management/commands/ldap_sync_users.py
@@ -4,15 +4,35 @@ from django.db import transaction
 
 from django_python3_ldap import ldap
 from django_python3_ldap.conf import settings
+from django_python3_ldap.utils import chunk_lookup_args
 
 
 class Command(BaseCommand):
 
-    help = "Creates local user models for all users found in the remote LDAP authentication server."
+    help = "Creates local user models for users found in the remote LDAP authentication server."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            'lookups',
+            nargs='*',
+            type=str,
+            help='A list of lookup values, matching the fields specified in LDAP_AUTH_USER_LOOKUP_FIELDS. '
+                 'If this is not provided then ALL users are synced.'
+        )
+
+    @staticmethod
+    def _iter_synced_users(connection, lookups):
+        if len(lookups) < 1:
+            for user in connection.iter_users():
+                yield user
+        else:
+            for chunk in chunk_lookup_args(*lookups):
+                yield connection.get_user(**chunk)
 
     @transaction.atomic()
     def handle(self, *args, **kwargs):
         verbosity = int(kwargs.get("verbosity", 1))
+        lookups = kwargs.get('lookups', [])
         User = get_user_model()
         auth_kwargs = {
             User.USERNAME_FIELD: settings.LDAP_AUTH_CONNECTION_USERNAME,
@@ -21,7 +41,7 @@ class Command(BaseCommand):
         with ldap.connection(**auth_kwargs) as connection:
             if connection is None:
                 raise CommandError("Could not connect to LDAP server")
-            for user in connection.iter_users():
+            for user in self._iter_synced_users(connection, lookups):
                 if verbosity >= 1:
                     self.stdout.write("Synced {user}".format(
                         user=user,

--- a/django_python3_ldap/tests.py
+++ b/django_python3_ldap/tests.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from unittest import skipUnless, skip
 from io import StringIO
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.contrib.auth import authenticate
 from django.contrib.auth.models import User
 from django.conf import settings as django_settings
@@ -140,6 +140,20 @@ class TestLdap(TestCase):
     def testSyncUsersCreatesUsers(self):
         call_command("ldap_sync_users", verbosity=0)
         self.assertGreater(User.objects.count(), 0)
+
+    def testSyncUserWithLookup(self):
+        call_command("ldap_sync_users", settings.LDAP_AUTH_TEST_USER_USERNAME, verbosity=0)
+        self.assertEqual(User.objects.filter(username=settings.LDAP_AUTH_TEST_USER_USERNAME).count(), 1)
+
+    @override_settings(LDAP_AUTH_USER_LOOKUP_FIELDS=('username', 'email'))
+    def testSyncUserWithMultipleLookups(self):
+        call_command(
+            "ldap_sync_users",
+            settings.LDAP_AUTH_TEST_USER_USERNAME,
+            settings.LDAP_AUTH_TEST_USER_EMAIL,
+            verbosity=0
+        )
+        self.assertEqual(User.objects.filter(username=settings.LDAP_AUTH_TEST_USER_USERNAME).count(), 1)
 
     def testSyncUsersCommandOutput(self):
         out = StringIO()

--- a/django_python3_ldap/utils.py
+++ b/django_python3_ldap/utils.py
@@ -4,6 +4,8 @@ Some useful LDAP utilities.
 
 import re
 import binascii
+import itertools
+
 from django.utils.encoding import force_text
 from django.utils.module_loading import import_string
 
@@ -121,3 +123,19 @@ def format_search_filters(ldap_fields):
         for field_name, field_value
         in ldap_fields.items()
     ]
+
+
+def chunk_lookup_args(*args):
+    """
+    Yields the given series of arguments as chunks, formatted as dictionaries, which represent field lookups
+    according to the LDAP_AUTH_USER_LOOKUP_FIELDS setting.
+
+    Based on the itertools grouper recipe: https://docs.python.org/3/library/itertools.html#itertools-recipes
+    """
+    fields_len = len(settings.LDAP_AUTH_USER_LOOKUP_FIELDS)
+    fields = [iter(args)] * fields_len
+    for chunk in itertools.zip_longest(*fields, fillvalue=None):
+        lookup = {}
+        for i in range(fields_len):
+            lookup[settings.LDAP_AUTH_USER_LOOKUP_FIELDS[i]] = chunk[i]
+        yield lookup

--- a/django_python3_ldap/utils.py
+++ b/django_python3_ldap/utils.py
@@ -125,7 +125,7 @@ def format_search_filters(ldap_fields):
     ]
 
 
-def chunk_lookup_args(*args):
+def group_lookup_args(*args):
     """
     Yields the given series of arguments as chunks, formatted as dictionaries, which represent field lookups
     according to the LDAP_AUTH_USER_LOOKUP_FIELDS setting.

--- a/tests/django_python3_ldap_test/settings.py
+++ b/tests/django_python3_ldap_test/settings.py
@@ -42,6 +42,8 @@ AUTHENTICATION_BACKENDS = (
 
 LDAP_AUTH_TEST_USER_USERNAME = "tesla"
 
+LDAP_AUTH_TEST_USER_EMAIL = "tesla@ldap.forumsys.com"
+
 LDAP_AUTH_TEST_USER_PASSWORD = "password"
 
 


### PR DESCRIPTION
Hello! This is a proposed addition which resolves #199. An optional positional argument is added to the `ldap_sync_users` management command, which allows the caller to provide a list of lookups to sync individual users if desired. As described in the issue, this essentially "chunks" the lookups based on the _n_ fields in `LDAP_AUTH_USER_LOOKUP_FIELDS`. Two tests are also added to cover this new behavior.