### PR TITLE
Update for Django 4

### DIFF
--- a/django_python3_ldap/utils.py
+++ b/django_python3_ldap/utils.py
@@ -6,7 +6,11 @@ import re
 import binascii
 import itertools
 
-from django.utils.encoding import force_text
+try:
+    from django.utils.encoding import force_str
+except ImportError:
+    from django.utils.encoding import force_text as force_str
+
 from django.utils.module_loading import import_string
 
 from django_python3_ldap.conf import settings
@@ -27,8 +31,8 @@ def clean_ldap_name(name):
     """
     return re.sub(
         r'[^a-zA-Z0-9 _\-.@:*]',
-        lambda c: "\\" + force_text(binascii.hexlify(c.group(0).encode("latin-1", errors="ignore"))).upper(),
-        force_text(name),
+        lambda c: "\\" + force_str(binascii.hexlify(c.group(0).encode("latin-1", errors="ignore"))).upper(),
+        force_str(name),
     )
 
 


### PR DESCRIPTION
As force_text is now removed with Django 4, force_str should be used instead, see [here](https://docs.djangoproject.com/en/4.0/releases/4.0/).