### PR TITLE
Allows overriding the SSL/TLS version. (fixes `SSLV3_ALERT_HANDSHAKE_FAILURE` in Python 3.10)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,10 @@ Available settings
     # Initiate TLS on connection.
     LDAP_AUTH_USE_TLS = False
 
+    # Specify which TLS version to use (Python 3.10 requires TLSv1 or higher)
+    import ssl
+    LDAP_AUTH_TLS_VERSION = ssl.PROTOCOL_TLSv1_2
+
     # The LDAP search base for looking up users.
     LDAP_AUTH_SEARCH_BASE = "ou=people,dc=example,dc=com"
 

--- a/django_python3_ldap/conf.py
+++ b/django_python3_ldap/conf.py
@@ -43,6 +43,11 @@ class LazySettings(object):
         default=False,
     )
 
+    LDAP_AUTH_TLS_VERSION = LazySetting(
+        name="LDAP_AUTH_TLS_VERSION",
+        default="SSLv3",
+    )
+
     LDAP_AUTH_SEARCH_BASE = LazySetting(
         name="LDAP_AUTH_SEARCH_BASE",
         default="ou=people,dc=example,dc=com",

--- a/django_python3_ldap/ldap.py
+++ b/django_python3_ldap/ldap.py
@@ -167,20 +167,21 @@ def connection(**kwargs):
     # Connect.
     try:
         # Include SSL / TLS, if requested.
+        connection_args = {
+            "user": username,
+            "password": password,
+            "auto_bind": False,
+            "raise_exceptions": True,
+            "receive_timeout": settings.LDAP_AUTH_RECEIVE_TIMEOUT,
+        }
         if settings.LDAP_AUTH_USE_TLS:
-            tls = ldap3.Tls(
+            connection_args["tls"] = ldap3.Tls(
                 ciphers='ALL',
                 version=settings.LDAP_AUTH_TLS_VERSION,
             )
-
         c = ldap3.Connection(
             server_pool,
-            user=username,
-            password=password,
-            auto_bind=False,
-            raise_exceptions=True,
-            receive_timeout=settings.LDAP_AUTH_RECEIVE_TIMEOUT,
-            tls=tls,
+            **connection_args,
         )
     except LDAPException as ex:
         logger.warning("LDAP connect failed: {ex}".format(ex=ex))

--- a/django_python3_ldap/ldap.py
+++ b/django_python3_ldap/ldap.py
@@ -166,6 +166,13 @@ def connection(**kwargs):
         )
     # Connect.
     try:
+        # Include SSL / TLS, if requested.
+        if settings.LDAP_AUTH_USE_TLS:
+            tls = ldap3.Tls(
+                ciphers='ALL',
+                version=settings.LDAP_AUTH_TLS_VERSION,
+            )
+
         c = ldap3.Connection(
             server_pool,
             user=username,
@@ -173,6 +180,7 @@ def connection(**kwargs):
             auto_bind=False,
             raise_exceptions=True,
             receive_timeout=settings.LDAP_AUTH_RECEIVE_TIMEOUT,
+            tls=tls,
         )
     except LDAPException as ex:
         logger.warning("LDAP connect failed: {ex}".format(ex=ex))
@@ -180,9 +188,6 @@ def connection(**kwargs):
         return
     # Configure.
     try:
-        # Start TLS, if requested.
-        if settings.LDAP_AUTH_USE_TLS:
-            c.start_tls(read_server_info=False)
         # Perform initial authentication bind.
         c.bind(read_server_info=True)
         # If the settings specify an alternative username and password for querying, rebind as that.


### PR DESCRIPTION
Python 3.10 has upped its security protocols, removing `SSLv3` by default. `ldap3` and the underlying OpenSSL libraries still try to fall back on this version as a default, which leads to an `SSLV3_ALERT_HANDSHAKE_FAILURE`.

This patch allows a new setting, `LDAP_AUTH_TLS_VERSION`, which allows specifying a TLS version available in the standard `ssl` library. It connects to LDAP using a `Tls` object from `ldap3` rather than the `start_tls()` function, allowing us to specify the version we need.

Thanks for the amazing package, @etianen - we have been keen users of it for years!