### PR TITLE
Bug fix: TLS object must go on the server, not connection.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 django-python3-ldap
 ===================
 
-**django-python3-ldap** provides a Django LDAP user authentication backend.
+**django-python3-ldap** provides a Django LDAP user authentication backend. Python 3.6+ is required.
 
 
 Features

--- a/django_python3_ldap/conf.py
+++ b/django_python3_ldap/conf.py
@@ -1,6 +1,7 @@
 """
 Settings used by django-python3.
 """
+from ssl import PROTOCOL_SSLv23
 
 from django.conf import settings
 
@@ -45,7 +46,7 @@ class LazySettings(object):
 
     LDAP_AUTH_TLS_VERSION = LazySetting(
         name="LDAP_AUTH_TLS_VERSION",
-        default="SSLv3",
+        default=PROTOCOL_SSLv23,
     )
 
     LDAP_AUTH_SEARCH_BASE = LazySetting(

--- a/django_python3_ldap/conf.py
+++ b/django_python3_ldap/conf.py
@@ -1,7 +1,7 @@
 """
 Settings used by django-python3.
 """
-from ssl import PROTOCOL_SSLv23
+from ssl import PROTOCOL_TLS
 
 from django.conf import settings
 
@@ -46,7 +46,7 @@ class LazySettings(object):
 
     LDAP_AUTH_TLS_VERSION = LazySetting(
         name="LDAP_AUTH_TLS_VERSION",
-        default=PROTOCOL_SSLv23,
+        default=PROTOCOL_TLS,
     )
 
     LDAP_AUTH_SEARCH_BASE = LazySetting(


### PR DESCRIPTION
This fixes #245 - my apologies for the faulty PR.

This appeared to be working because I had a Django model backend prioritized before the LDAP backend, which was causing the code to appear to work after receiving errors for quite some time, when in fact, the error was no longer triggered but the login was still being handled by the model backend.
