### PR TITLE
Support for setting prefixes that  support multiple backends

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 django-python3-ldap
 ===================
 
-**django-python3-ldap** provides a Django LDAP user authentication backend.
+**django-python3-ldap** provides a Django LDAP user authentication backend.  Python 3.6+ is required.
 
 
 Features
@@ -38,10 +38,9 @@ Available settings
     LDAP_AUTH_USE_TLS = False
 
 
-    # SSL or TLS version to use, can be one of the following: SSLv2, SSLv3, SSLv23, TLSv1 (as per Python 3.3.
-      The version list can be different in other Python versions)
+    # Specify which TLS version to use (Python 3.10 requires TLSv1 or higher)
     import ssl
-    LDAP_AUTH_TLS_VERSION = ssl.PROTOCOL_TLS
+    LDAP_AUTH_TLS_VERSION = ssl.PROTOCOL_TLSv1_2
 
     # Specifies if the server certificate must be validated, values can be: CERT_NONE (certificates are ignored),
     CERT_OPTIONAL (not required, but validated if provided) and CERT_REQUIRED (required and validated)

--- a/django_python3_ldap/auth.py
+++ b/django_python3_ldap/auth.py
@@ -5,7 +5,8 @@ Django authentication backend.
 from django.contrib.auth.backends import ModelBackend
 
 from django_python3_ldap import ldap
-
+from django_python3_ldap.conf import LazySettings
+from django.conf import settings
 
 class LDAPBackend(ModelBackend):
 
@@ -18,6 +19,16 @@ class LDAPBackend(ModelBackend):
     """
 
     supports_inactive_user = False
+    settings_prefix = "LDAP_AUTH"
 
     def authenticate(self, *args, **kwargs):
-        return ldap.authenticate(*args, **kwargs)
+        prefixed_settings = self.get_settings()
+        return ldap.authenticate(*args, settings=prefixed_settings, **kwargs)
+
+    @classmethod
+    def get_settings(cls):
+        """
+        Retrieve settings proxy object based on `settings_prefix`.
+        :return: A LazySettings object to be used for authentication.
+        """
+        return LazySettings(settings, settings_prefix=cls.settings_prefix)

--- a/django_python3_ldap/conf.py
+++ b/django_python3_ldap/conf.py
@@ -1,13 +1,12 @@
 """
 Settings used by django-python3.
 """
-from ssl import PROTOCOL_TLS
-
+import ldap3
+import ssl
 from django.conf import settings
 
 
 class LazySetting(object):
-
     """
     A proxy to a named Django setting.
     """
@@ -19,11 +18,10 @@ class LazySetting(object):
     def __get__(self, obj, cls):
         if obj is None:
             return self
-        return getattr(obj._settings, self.name, self.default)
+        return getattr(obj._settings, obj.settings_prefix + '_' + self.name, self.default)
 
 
 class LazySettings(object):
-
     """
     A proxy to ldap-specific django settings.
 
@@ -31,36 +29,57 @@ class LazySettings(object):
     to change settings at runtime.
     """
 
-    def __init__(self, settings):
+    def __init__(self, settings, settings_prefix="LDAP_AUTH"):
         self._settings = settings
+        self.settings_prefix = settings_prefix
 
     LDAP_AUTH_URL = LazySetting(
-        name="LDAP_AUTH_URL",
+        name="URL",
         default=["ldap://localhost:389"],
     )
 
     LDAP_AUTH_USE_TLS = LazySetting(
-        name="LDAP_AUTH_USE_TLS",
+        name="USE_TLS",
         default=False,
     )
 
     LDAP_AUTH_TLS_VERSION = LazySetting(
-        name="LDAP_AUTH_TLS_VERSION",
-        default=PROTOCOL_TLS,
+        name="TLS_VERSION",
+        default=None,
+    )
+
+    LDAP_AUTH_TLS_VALIDATE_CERT = LazySetting(
+        name="TLS_VALIDATE_CERT",
+        default=ssl.VERIFY_DEFAULT,
+    )
+
+    LDAP_AUTH_TLS_LOCAL_CERT_FILE = LazySetting(
+        name="TLS_LOCAL_CERT_FILE",
+        default=None,
+    )
+
+    LDAP_AUTH_TLS_CA_CERTS_FILE = LazySetting(
+        name="TLS_CA_CERTS_FILE",
+        default=None,
+    )
+
+    LDAP_AUTH_TLS_CIPHERS = LazySetting(
+        name="TLS_CIPHERS",
+        default=None,
     )
 
     LDAP_AUTH_SEARCH_BASE = LazySetting(
-        name="LDAP_AUTH_SEARCH_BASE",
+        name="SEARCH_BASE",
         default="ou=people,dc=example,dc=com",
     )
 
     LDAP_AUTH_OBJECT_CLASS = LazySetting(
-        name="LDAP_AUTH_OBJECT_CLASS",
+        name="OBJECT_CLASS",
         default="inetOrgPerson",
     )
 
     LDAP_AUTH_USER_FIELDS = LazySetting(
-        name="LDAP_AUTH_USER_FIELDS",
+        name="USER_FIELDS",
         default={
             "username": "uid",
             "first_name": "givenName",
@@ -70,69 +89,75 @@ class LazySettings(object):
     )
 
     LDAP_AUTH_USER_LOOKUP_FIELDS = LazySetting(
-        name="LDAP_AUTH_USER_LOOKUP_FIELDS",
+        name="USER_LOOKUP_FIELDS",
         default=(
             "username",
         ),
     )
 
     LDAP_AUTH_CLEAN_USER_DATA = LazySetting(
-        name="LDAP_AUTH_CLEAN_USER_DATA",
+        name="CLEAN_USER_DATA",
         default="django_python3_ldap.utils.clean_user_data",
     )
 
     LDAP_AUTH_FORMAT_SEARCH_FILTERS = LazySetting(
-        name="LDAP_AUTH_FORMAT_SEARCH_FILTERS",
+        name="FORMAT_SEARCH_FILTERS",
         default="django_python3_ldap.utils.format_search_filters",
     )
 
+
     LDAP_AUTH_SYNC_USER_RELATIONS = LazySetting(
-        name="LDAP_AUTH_SYNC_USER_RELATIONS",
+        name="SYNC_USER_RELATIONS",
         default="django_python3_ldap.utils.sync_user_relations",
     )
 
     LDAP_AUTH_FORMAT_USERNAME = LazySetting(
-        name="LDAP_AUTH_FORMAT_USERNAME",
+        name="FORMAT_USERNAME",
         default="django_python3_ldap.utils.format_username_openldap",
     )
 
+    LDAP_AUTH_ATTRIBUTES = LazySetting(
+        name="ATTRIBUTES",
+        default=ldap3.ALL_ATTRIBUTES,
+    )
+
     LDAP_AUTH_ACTIVE_DIRECTORY_DOMAIN = LazySetting(
-        name="LDAP_AUTH_ACTIVE_DIRECTORY_DOMAIN",
+        name="ACTIVE_DIRECTORY_DOMAIN",
         default=None,
     )
 
     LDAP_AUTH_TEST_USER_USERNAME = LazySetting(
-        name="LDAP_AUTH_TEST_USER_USERNAME",
+        name="TEST_USER_USERNAME",
         default="",
     )
 
     LDAP_AUTH_TEST_USER_EMAIL = LazySetting(
-        name="LDAP_AUTH_TEST_USER_EMAIL",
+        name="TEST_USER_EMAIL",
         default=""
     )
 
     LDAP_AUTH_TEST_USER_PASSWORD = LazySetting(
-        name="LDAP_AUTH_TEST_USER_PASSWORD",
+        name="TEST_USER_PASSWORD",
         default="",
     )
 
     LDAP_AUTH_CONNECTION_USERNAME = LazySetting(
-        name="LDAP_AUTH_CONNECTION_USERNAME",
+        name="CONNECTION_USERNAME",
         default=None,
     )
 
     LDAP_AUTH_CONNECTION_PASSWORD = LazySetting(
-        name="LDAP_AUTH_CONNECTION_PASSWORD",
+        name="CONNECTION_PASSWORD",
         default=None,
     )
 
     LDAP_AUTH_CONNECT_TIMEOUT = LazySetting(
-        name="LDAP_AUTH_CONNECT_TIMEOUT",
+        name="CONNECT_TIMEOUT",
         default=None
     )
 
     LDAP_AUTH_RECEIVE_TIMEOUT = LazySetting(
-        name="LDAP_AUTH_RECEIVE_TIMEOUT",
+        name="RECEIVE_TIMEOUT",
         default=None
     )
 

--- a/django_python3_ldap/management/commands/ldap_sync_users.py
+++ b/django_python3_ldap/management/commands/ldap_sync_users.py
@@ -3,21 +3,34 @@ from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 
 from django_python3_ldap import ldap
-from django_python3_ldap.conf import settings
-from django_python3_ldap.utils import group_lookup_args
+from django.utils.module_loading import import_string
+from django_python3_ldap.utils import group_lookup_args, get_all_backend_settings
+from django_python3_ldap.auth import LDAPBackend
 
 
 class Command(BaseCommand):
-
     help = "Creates local user models for users found in the remote LDAP authentication server."
+    backends = None
+
+    def __init__(self, *args, **kwargs):
+        self.backends = get_all_backend_settings()
+        super().__init__(*args, **kwargs)
 
     def add_arguments(self, parser):
         parser.add_argument(
             'lookups',
             nargs='*',
-            type=str,
             help='A list of lookup values, matching the fields specified in LDAP_AUTH_USER_LOOKUP_FIELDS. '
                  'If this is not provided then ALL users are synced.'
+        )
+
+        parser.add_argument(
+            '--backend',
+            action='append',
+            default=list(self.backends.keys()) ,
+            choices=list(self.backends.keys()),
+            help='Limit action to a specific authentication backend instance.\n'
+                 'Options include ' + ",".join(self.backends.keys())
         )
 
     @staticmethod
@@ -33,16 +46,25 @@ class Command(BaseCommand):
             for lookup in group_lookup_args(*lookups):
                 yield connection.get_user(**lookup)
 
+
     @transaction.atomic()
     def handle(self, *args, **kwargs):
         verbosity = int(kwargs.get("verbosity", 1))
         lookups = kwargs.get('lookups', [])
+        backend_names = kwargs.get('backend', None)
+
+        for backend in backend_names:
+           settings = self.backends[backend]
+           self.do_sync_for_backend(settings, lookups, verbosity)
+
+    def do_sync_for_backend(self, settings, lookups, verbosity):
         User = get_user_model()
         auth_kwargs = {
             User.USERNAME_FIELD: settings.LDAP_AUTH_CONNECTION_USERNAME,
             'password': settings.LDAP_AUTH_CONNECTION_PASSWORD
         }
-        with ldap.connection(**auth_kwargs) as connection:
+
+        with ldap.connection(settings, **auth_kwargs) as connection:
             if connection is None:
                 raise CommandError("Could not connect to LDAP server")
             for user in self._iter_synced_users(connection, lookups):

--- a/django_python3_ldap/utils.py
+++ b/django_python3_ldap/utils.py
@@ -5,6 +5,10 @@ Some useful LDAP utilities.
 import re
 import binascii
 import itertools
+from inspect import signature
+from .conf import settings as ldap_conf_unprefixed_settings
+from django.contrib.auth import load_backend
+
 
 try:
     from django.utils.encoding import force_str
@@ -12,8 +16,21 @@ except ImportError:
     from django.utils.encoding import force_text as force_str
 
 from django.utils.module_loading import import_string
+from django.conf import settings as django_settings
 
-from django_python3_ldap.conf import settings
+
+def call_custom_func(func, settings, *args, **kwargs):
+    """
+    Help to call a "utils" function with optionals settings keywards.
+    To support for multiple LDAP configurations, and functions may now accept backend specific `settings` instance
+    eyword argument. For backward compatibility `call_custom_func` injects settings into kwargs only if the function
+    accepts an explicitly named argument `settings`.
+    :return: Value returned from calling func
+    """
+    func = import_func(func)
+    if signature(func).parameters.get('settings'):
+        kwargs['settings'] = settings
+    return func(*args, **kwargs)
 
 
 def import_func(func):
@@ -36,7 +53,7 @@ def clean_ldap_name(name):
     )
 
 
-def convert_model_fields_to_ldap_fields(model_fields):
+def convert_model_fields_to_ldap_fields(model_fields, settings):
     """
     Converts a set of model fields into a set of corresponding
     LDAP fields.
@@ -48,14 +65,15 @@ def convert_model_fields_to_ldap_fields(model_fields):
     }
 
 
-def format_search_filter(model_fields):
+def format_search_filter(model_fields, settings):
     """
     Creates an LDAP search filter for the given set of model
     fields.
     """
-    ldap_fields = convert_model_fields_to_ldap_fields(model_fields)
+    settings = settings or ldap_conf_unprefixed_settings
+    ldap_fields = convert_model_fields_to_ldap_fields(model_fields, settings)
     ldap_fields["objectClass"] = settings.LDAP_AUTH_OBJECT_CLASS
-    search_filters = import_func(settings.LDAP_AUTH_FORMAT_SEARCH_FILTERS)(ldap_fields)
+    search_filters = call_custom_func(settings.LDAP_AUTH_FORMAT_SEARCH_FILTERS, settings, ldap_fields)
     return "(&{})".format("".join(search_filters))
 
 
@@ -67,11 +85,12 @@ def clean_user_data(model_fields):
     return model_fields
 
 
-def format_username_openldap(model_fields):
+def format_username_openldap(model_fields, settings=None):
     """
     Formats a user identifier into a username suitable for
     binding to an OpenLDAP server.
     """
+    settings = settings or ldap_conf_unprefixed_settings  # For backwards compatibility.
     return "{user_identifier},{search_base}".format(
         user_identifier=",".join(
             "{attribute_name}={field_value}".format(
@@ -85,11 +104,12 @@ def format_username_openldap(model_fields):
     )
 
 
-def format_username_active_directory(model_fields):
+def format_username_active_directory(model_fields, settings=None):
     """
     Formats a user identifier into a username suitable for
     binding to an Active Directory server.
     """
+    settings = settings or ldap_conf_unprefixed_settings
     username = model_fields["username"]
     if settings.LDAP_AUTH_ACTIVE_DIRECTORY_DOMAIN:
         username = "{domain}\\{username}".format(
@@ -99,11 +119,12 @@ def format_username_active_directory(model_fields):
     return username
 
 
-def format_username_active_directory_principal(model_fields):
+def format_username_active_directory_principal(model_fields, settings=None):
     """
     Formats a user identifier into a username suitable for
     binding to an Active Directory server.
     """
+    settings = settings or ldap_conf_unprefixed_settings
     username = model_fields["username"]
     if settings.LDAP_AUTH_ACTIVE_DIRECTORY_DOMAIN:
         username = "{username}@{domain}".format(
@@ -113,12 +134,12 @@ def format_username_active_directory_principal(model_fields):
     return username
 
 
-def sync_user_relations(user, ldap_attributes, *, connection=None, dn=None):
+def sync_user_relations(user, ldap_attributes, *, connection=None, dn=None, settings=None):
     # do nothing by default
     pass
 
 
-def format_search_filters(ldap_fields):
+def format_search_filters(ldap_fields, settings=None):
     return [
         "({attribute_name}={field_value})".format(
             attribute_name=clean_ldap_name(field_name),
@@ -129,13 +150,14 @@ def format_search_filters(ldap_fields):
     ]
 
 
-def group_lookup_args(*args):
+def group_lookup_args(*args, settings=None):
     """
     Yields the given series of arguments as chunks, formatted as dictionaries, which represent field lookups
     according to the LDAP_AUTH_USER_LOOKUP_FIELDS setting.
 
     Based on the itertools grouper recipe: https://docs.python.org/3/library/itertools.html#itertools-recipes
     """
+    settings = settings or ldap_conf_unprefixed_settings
     fields_len = len(settings.LDAP_AUTH_USER_LOOKUP_FIELDS)
     fields = [iter(args)] * fields_len
     for chunk in itertools.zip_longest(*fields, fillvalue=None):
@@ -143,3 +165,18 @@ def group_lookup_args(*args):
         for i in range(fields_len):
             lookup[settings.LDAP_AUTH_USER_LOOKUP_FIELDS[i]] = chunk[i]
         yield lookup
+
+
+def get_all_backend_settings():
+    """
+    Retrieve a Dict of Authenticaton backend classpaths and settings, that subclass this module. Subclasses can have
+    unique `settings_prefix` attribute can be used to configure multiple ldap authentication backends concurrently.
+    :return: Dict class_path -> settings.
+    """
+    out = {}
+    from django_python3_ldap.auth import LDAPBackend  # Avoid circular references
+    for backend_path in django_settings.AUTHENTICATION_BACKENDS:
+        backend = load_backend(backend_path)
+        if isinstance(backend, LDAPBackend):
+            out[backend_path] = backend.get_settings()
+    return out


### PR DESCRIPTION
 - Add support for being loaded as multiple auth backends with configurable settings prefix to allow different configurations.
- Additional options for TLS and certificate validation
- Additional option 'ATTRIBUTES' to limit (or increase) the size of records returned by the server.
