### PR TITLE
Add support for additional configuration options 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ docs/_build
 *.sqlite3
 .coverage
 *.egg-info
+.venv

--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,12 @@ Available settings
     # CERT_OPTIONAL is not secure and it is recommended that CERT_REQUIRED is used.
     LDAP_AUTH_TLS_VALIDATE_CERT = ssl.CERT_OPTIONAL
 
+
+    # LDAP_AUTH_TLS_CA_CERTS_FILE a file containing the certificates of trusted certification authorities. Option is valid
+    only when using SSLContext (i.e. python 2.7.9+ and python 3.4+).
+    LDAP_AUTH_TLS_CA_CERTS_FILE = None
+
+
     # String in the  OpenSSL cipher list format specifying which ciphers must be used. See https://ldap3.readthedocs.io/en/latest/ssltls.html . It
     # works on recent Python interpreters that allow to change the cipher in the SSLContext or in the the wrap_socket()
     #method, it’s ignored on older versions.

--- a/README.rst
+++ b/README.rst
@@ -46,10 +46,6 @@ Available settings
     # CERT_OPTIONAL is not secure and it is recommended that CERT_REQUIRED is used.
     LDAP_AUTH_TLS_VALIDATE_CERT = ssl.CERT_OPTIONAL
 
-    # A string must be the path to a file in PEM format containing the server, and any number of CA certificates needed
-    # to establish the server certificate’s authenticity.
-     = None
-
     # String in the  OpenSSL cipher list format specifying which ciphers must be used. See https://ldap3.readthedocs.io/en/latest/ssltls.html . It
     # works on recent Python interpreters that allow to change the cipher in the SSLContext or in the the wrap_socket()
     #method, it’s ignored on older versions.

--- a/README.rst
+++ b/README.rst
@@ -46,10 +46,8 @@ Available settings
     # is not secure and it is recommended that CERT_REQUIRED is used instead.
     LDAP_AUTH_TLS_VALIDATE_CERT = None
 
-
     # LDAP_AUTH_TLS_CA_CERTS_FILE a file containing the certificates of trusted certification authorities.
     LDAP_AUTH_TLS_CA_CERTS_FILE = None
-
 
     # String in the  OpenSSL cipher list format specifying which ciphers must be used. See https://ldap3.readthedocs.io/en/latest/ssltls.html . It
     # works on recent Python interpreters that allow to change the cipher in the SSLContext or in the the wrap_socket()
@@ -70,7 +68,6 @@ Available settings
         "last_name": "sn",
         "email": "mail",
     }
-
 
     # A tuple of django model fields used to uniquely identify a user.
     LDAP_AUTH_USER_LOOKUP_FIELDS = ("username",)

--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,20 @@ Available settings
     import ssl
     LDAP_AUTH_TLS_VERSION = ssl.PROTOCOL_TLSv1_2
 
+    # Specifies if the server certificate must be validated, values can be: CERT_NONE (certificates are ignored),
+    # CERT_OPTIONAL (not required, but validated if provided) and CERT_REQUIRED (required and validated). The default
+    # CERT_OPTIONAL is not secure and it is recommended that CERT_REQUIRED is used.
+    LDAP_AUTH_TLS_VALIDATE_CERT = ssl.CERT_OPTIONAL
+
+    # A string must be the path to a file in PEM format containing the server, and any number of CA certificates needed
+    # to establish the server certificate’s authenticity.
+     = None
+
+    # String in the  OpenSSL cipher list format specifying which ciphers must be used. See https://ldap3.readthedocs.io/en/latest/ssltls.html . It
+    # works on recent Python interpreters that allow to change the cipher in the SSLContext or in the the wrap_socket()
+    #method, it’s ignored on older versions.
+    LDAP_AUTH_TLS_CIPHERS = None
+
     # The LDAP search base for looking up users.
     LDAP_AUTH_SEARCH_BASE = "ou=people,dc=example,dc=com"
 
@@ -55,6 +69,7 @@ Available settings
         "last_name": "sn",
         "email": "mail",
     }
+
 
     # A tuple of django model fields used to uniquely identify a user.
     LDAP_AUTH_USER_LOOKUP_FIELDS = ("username",)
@@ -80,6 +95,9 @@ Available settings
     # a string of the username to bind to the LDAP server.
     # Use this to support different types of LDAP server.
     LDAP_AUTH_FORMAT_USERNAME = "django_python3_ldap.utils.format_username_openldap"
+
+    # A single attribute or a list of attributes to be returned by LDAP operations.
+    LDAP_AUTH_ATTRIBUTES = ldap3.ALL_ATTRIBUTES
 
     # Sets the login domain for Active Directory users.
     LDAP_AUTH_ACTIVE_DIRECTORY_DOMAIN = None

--- a/README.rst
+++ b/README.rst
@@ -43,12 +43,11 @@ Available settings
 
     # Specifies if the server certificate must be validated, values can be: CERT_NONE (certificates are ignored),
     # CERT_OPTIONAL (not required, but validated if provided) and CERT_REQUIRED (required and validated). The default
-    # CERT_OPTIONAL is not secure and it is recommended that CERT_REQUIRED is used.
-    LDAP_AUTH_TLS_VALIDATE_CERT = ssl.CERT_OPTIONAL
+    # is not secure and it is recommended that CERT_REQUIRED is used instead.
+    LDAP_AUTH_TLS_VALIDATE_CERT = None
 
 
-    # LDAP_AUTH_TLS_CA_CERTS_FILE a file containing the certificates of trusted certification authorities. Option is valid
-    only when using SSLContext (i.e. python 2.7.9+ and python 3.4+).
+    # LDAP_AUTH_TLS_CA_CERTS_FILE a file containing the certificates of trusted certification authorities.
     LDAP_AUTH_TLS_CA_CERTS_FILE = None
 
 

--- a/django_python3_ldap/conf.py
+++ b/django_python3_ldap/conf.py
@@ -2,7 +2,6 @@
 Settings used by django-python3.
 """
 import ldap3
-import ssl
 from django.conf import settings
 
 

--- a/django_python3_ldap/conf.py
+++ b/django_python3_ldap/conf.py
@@ -1,8 +1,8 @@
 """
 Settings used by django-python3.
 """
-from ssl import PROTOCOL_TLS
-
+import ldap3
+import ssl
 from django.conf import settings
 
 
@@ -46,7 +46,22 @@ class LazySettings(object):
 
     LDAP_AUTH_TLS_VERSION = LazySetting(
         name="LDAP_AUTH_TLS_VERSION",
-        default=PROTOCOL_TLS,
+        default=None,
+    )
+
+    LDAP_AUTH_TLS_VALIDATE_CERT = LazySetting(
+        name="LDAP_AUTH_TLS_VALIDATE_CERT",
+        default=None,
+    )
+
+    LDAP_AUTH_TLS_CA_CERTS_FILE = LazySetting(
+        name="LDAP_AUTH_TLS_CA_CERTS_FILE",
+        default=None,
+    )
+
+    LDAP_AUTH_TLS_CIPHERS = LazySetting(
+        name="LDAP_AUTH_TLS_CIPHERS",
+        default=None,
     )
 
     LDAP_AUTH_SEARCH_BASE = LazySetting(
@@ -94,6 +109,11 @@ class LazySettings(object):
     LDAP_AUTH_FORMAT_USERNAME = LazySetting(
         name="LDAP_AUTH_FORMAT_USERNAME",
         default="django_python3_ldap.utils.format_username_openldap",
+    )
+
+    LDAP_AUTH_ATTRIBUTES = LazySetting(
+        name="LDAP_AUTH_ATTRIBUTES",
+        default=ldap3.ALL_ATTRIBUTES,
     )
 
     LDAP_AUTH_ACTIVE_DIRECTORY_DOMAIN = LazySetting(

--- a/django_python3_ldap/ldap.py
+++ b/django_python3_ldap/ldap.py
@@ -1,6 +1,7 @@
 """
 Low-level LDAP hooks.
 """
+import ssl
 
 import ldap3
 from ldap3.core.exceptions import LDAPException
@@ -97,7 +98,7 @@ class Connection(object):
             search_base=settings.LDAP_AUTH_SEARCH_BASE,
             search_filter=format_search_filter({}),
             search_scope=ldap3.SUBTREE,
-            attributes=ldap3.ALL_ATTRIBUTES,
+            attributes=settings.LDAP_AUTH_ATTRIBUTES,
             get_operational_attributes=True,
             paged_size=30,
         )
@@ -133,11 +134,36 @@ class Connection(object):
             search_base=settings.LDAP_AUTH_SEARCH_BASE,
             search_filter=format_search_filter(kwargs),
             search_scope=ldap3.SUBTREE,
-            attributes=ldap3.ALL_ATTRIBUTES,
+            attributes=settings.LDAP_AUTH_ATTRIBUTES,
             get_operational_attributes=True,
             size_limit=1,
         )
         return bool(len(self._connection.response) > 0 and self._connection.response[0].get("attributes"))
+
+
+def get_tls_options(settings):
+    tls_options = {}
+
+    if not settings.LDAP_AUTH_USE_TLS:
+        return None
+
+    tls_options['validate'] = settings.LDAP_AUTH_TLS_VALIDATE_CERT
+
+    if tls_options['validate'] != ssl.CERT_REQUIRED:
+        logger.info(
+            "LDAP_AUTH_VALIDATE_CERT is set to not ssl.CERT_REQUIRED, certificate validation may not be enforced. This configuration is considered insecure.")
+
+    if settings.LDAP_AUTH_TLS_CA_CERTS_FILE:
+        tls_options['ca_certs_file'] = settings.LDAP_AUTH_TLS_CA_CERTS_FILE
+
+    if settings.LDAP_AUTH_TLS_VERSION:
+        tls_options['version'] = settings.LDAP_AUTH_TLS_VERSION
+
+    if settings.LDAP_AUTH_TLS_CIPHERS:
+        tls_options['ciphers'] = settings.LDAP_AUTH_TLS_CIPHERS
+
+    return (ldap3.Tls(**tls_options))
+
 
 
 @contextmanager
@@ -167,25 +193,19 @@ def connection(**kwargs):
     if not isinstance(auth_url, list):
         auth_url = [auth_url]
     for u in auth_url:
-        # Include SSL / TLS, if requested.
-        server_args = {
-            "allowed_referral_hosts": [("*", True)],
-            "get_info": ldap3.NONE,
-            "connect_timeout": settings.LDAP_AUTH_CONNECT_TIMEOUT,
-        }
-        if settings.LDAP_AUTH_USE_TLS:
-            server_args["tls"] = ldap3.Tls(
-                ciphers="ALL",
-                version=settings.LDAP_AUTH_TLS_VERSION,
-            )
         server_pool.add(
             ldap3.Server(
                 u,
-                **server_args,
+                allowed_referral_hosts=[("*", True)],
+                get_info=ldap3.NONE,
+                connect_timeout=settings.LDAP_AUTH_CONNECT_TIMEOUT,
+                tls=get_tls_options(settings),
+                use_ssl=settings.LDAP_AUTH_USE_TLS
             )
         )
     # Connect.
     try:
+        # Include SSL / TLS, if requested.
         connection_args = {
             "user": username,
             "password": password,

--- a/django_python3_ldap/ldap.py
+++ b/django_python3_ldap/ldap.py
@@ -147,11 +147,8 @@ def get_tls_options(settings):
     if not settings.LDAP_AUTH_USE_TLS:
         return None
 
-    tls_options['validate'] = settings.LDAP_AUTH_TLS_VALIDATE_CERT
-
-    if tls_options['validate'] != ssl.CERT_REQUIRED:
-        logger.info(
-            "LDAP_AUTH_VALIDATE_CERT is set to not ssl.CERT_REQUIRED, certificate validation may not be enforced. This configuration is considered insecure.")
+    if settings.LDAP_AUTH_TLS_VALIDATE_CERT:
+       tls_options['validate'] = settings.LDAP_AUTH_TLS_VALIDATE_CERT
 
     if settings.LDAP_AUTH_TLS_CA_CERTS_FILE:
         tls_options['ca_certs_file'] = settings.LDAP_AUTH_TLS_CA_CERTS_FILE

--- a/django_python3_ldap/ldap.py
+++ b/django_python3_ldap/ldap.py
@@ -1,7 +1,6 @@
 """
 Low-level LDAP hooks.
 """
-import ssl
 
 import ldap3
 from ldap3.core.exceptions import LDAPException
@@ -148,7 +147,7 @@ def get_tls_options(settings):
         return None
 
     if settings.LDAP_AUTH_TLS_VALIDATE_CERT:
-       tls_options['validate'] = settings.LDAP_AUTH_TLS_VALIDATE_CERT
+        tls_options['validate'] = settings.LDAP_AUTH_TLS_VALIDATE_CERT
 
     if settings.LDAP_AUTH_TLS_CA_CERTS_FILE:
         tls_options['ca_certs_file'] = settings.LDAP_AUTH_TLS_CA_CERTS_FILE
@@ -160,7 +159,6 @@ def get_tls_options(settings):
         tls_options['ciphers'] = settings.LDAP_AUTH_TLS_CIPHERS
 
     return (ldap3.Tls(**tls_options))
-
 
 
 @contextmanager

--- a/django_python3_ldap/ldap.py
+++ b/django_python3_ldap/ldap.py
@@ -49,7 +49,7 @@ class Connection(object):
         user_fields = {
             field_name: (
                 attributes[attribute_name][0]
-                if isinstance(attributes[attribute_name], (list, tuple)) else
+                if isinstance(attributes[attribute_name], (list, tuple)) and len(attributes[attribute_name]) > 0 else
                 attributes[attribute_name]
             )
             for field_name, attribute_name

--- a/django_python3_ldap/tests.py
+++ b/django_python3_ldap/tests.py
@@ -410,6 +410,37 @@ class TestLdap(TestCase):
 @skipUnless(settings.LDAP_AUTH_TEST_USER_PASSWORD, "No settings.LDAP_AUTH_TEST_USER_PASSWORD supplied.")
 @skipUnless(settings.LDAP_AUTH_USER_LOOKUP_FIELDS == ("username",), "Cannot test using custom lookup fields.")
 @skipUnless(django_settings.AUTH_USER_MODEL == "auth.User", "Cannot test using a custom user model.")
+class TestAttrib(TestCase):
+
+    def setUp(self):
+        super(TestAttrib, self).setUp()
+        User.objects.all().delete()
+
+    def testSyncUsersCreatesUsers(self):
+        with self.settings(
+               LDAP_AUTH_ATTRIBUTES=['givenName', "homeDirectory",  "uid"],
+              LDAP_AUTH_USER_FIELDS={
+                    "username": "uid",
+                    "first_name": "givenName",
+                    "last_name": "homeDirectory",
+                    "email": "mail",
+                }
+
+        ):
+            user = authenticate(
+                username=settings.LDAP_AUTH_TEST_USER_USERNAME,
+                password=settings.LDAP_AUTH_TEST_USER_PASSWORD,
+            )
+            self.assertIsInstance(user, User)
+            self.assertEqual(user.last_name, 'home')
+            self.assertEqual(user.email, '')
+
+
+
+@skipUnless(settings.LDAP_AUTH_TEST_USER_USERNAME, "No settings.LDAP_AUTH_TEST_USER_USERNAME supplied.")
+@skipUnless(settings.LDAP_AUTH_TEST_USER_PASSWORD, "No settings.LDAP_AUTH_TEST_USER_PASSWORD supplied.")
+@skipUnless(settings.LDAP_AUTH_USER_LOOKUP_FIELDS == ("username",), "Cannot test using custom lookup fields.")
+@skipUnless(django_settings.AUTH_USER_MODEL == "auth.User", "Cannot test using a custom user model.")
 class TestSSL(TestCase):
 
     def setUp(self):

--- a/django_python3_ldap/tests.py
+++ b/django_python3_ldap/tests.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 import ssl
-from unittest import skipUnless, skip
+from unittest import skipUnless
 from io import StringIO
 
 from django.test import TestCase, override_settings
@@ -116,7 +116,6 @@ class TestLdap(TestCase):
         )
         # Ensure that the user isn't recreated on second access.
         self.assertEqual(user_1.pk, user_2.pk)
-
 
     def testAuthenticateWithRebind(self):
         with self.settings(
@@ -418,8 +417,8 @@ class TestAttrib(TestCase):
 
     def testSyncUsersCreatesUsers(self):
         with self.settings(
-               LDAP_AUTH_ATTRIBUTES=['givenName', "homeDirectory",  "uid"],
-              LDAP_AUTH_USER_FIELDS={
+                LDAP_AUTH_ATTRIBUTES=['givenName', "homeDirectory",  "uid"],
+                LDAP_AUTH_USER_FIELDS={
                     "username": "uid",
                     "first_name": "givenName",
                     "last_name": "homeDirectory",
@@ -434,7 +433,6 @@ class TestAttrib(TestCase):
             self.assertIsInstance(user, User)
             self.assertEqual(user.last_name, 'home')
             self.assertEqual(user.email, '')
-
 
 
 @skipUnless(settings.LDAP_AUTH_TEST_USER_USERNAME, "No settings.LDAP_AUTH_TEST_USER_USERNAME supplied.")

--- a/django_python3_ldap/tests.py
+++ b/django_python3_ldap/tests.py
@@ -1,6 +1,7 @@
 # encoding=utf-8
 from __future__ import unicode_literals
 
+import ssl
 from unittest import skipUnless, skip
 from io import StringIO
 
@@ -116,15 +117,6 @@ class TestLdap(TestCase):
         # Ensure that the user isn't recreated on second access.
         self.assertEqual(user_1.pk, user_2.pk)
 
-    @skip("FIXME: test server currently uses outdated TLS cyphers")
-    def testAuthenticateWithTLS(self):
-        with self.settings(LDAP_AUTH_USE_TLS=True):
-            user = authenticate(
-                username=settings.LDAP_AUTH_TEST_USER_USERNAME,
-                password=settings.LDAP_AUTH_TEST_USER_PASSWORD,
-            )
-            self.assertIsInstance(user, User)
-            self.assertEqual(user.username, settings.LDAP_AUTH_TEST_USER_USERNAME)
 
     def testAuthenticateWithRebind(self):
         with self.settings(
@@ -412,3 +404,32 @@ class TestLdap(TestCase):
         call_command("ldap_clean_users", verbosity=0, purge=True)
         user_count_2 = User.objects.count()
         self.assertEqual(user_count_1, user_count_2)
+
+
+@skipUnless(settings.LDAP_AUTH_TEST_USER_USERNAME, "No settings.LDAP_AUTH_TEST_USER_USERNAME supplied.")
+@skipUnless(settings.LDAP_AUTH_TEST_USER_PASSWORD, "No settings.LDAP_AUTH_TEST_USER_PASSWORD supplied.")
+@skipUnless(settings.LDAP_AUTH_USER_LOOKUP_FIELDS == ("username",), "Cannot test using custom lookup fields.")
+@skipUnless(django_settings.AUTH_USER_MODEL == "auth.User", "Cannot test using a custom user model.")
+class TestSSL(TestCase):
+
+    def setUp(self):
+        super(TestSSL, self).setUp()
+        User.objects.all().delete()
+
+    def testAuthenticateWithTLS(self):
+        with self.settings(LDAP_AUTH_USE_TLS=True, LDAP_AUTH_TLS_VALIDATE_CERT=ssl.CERT_NONE):
+            user = authenticate(
+                username=settings.LDAP_AUTH_TEST_USER_USERNAME,
+                password=settings.LDAP_AUTH_TEST_USER_PASSWORD,
+            )
+            self.assertIsInstance(user, User)
+            self.assertEqual(user.username, settings.LDAP_AUTH_TEST_USER_USERNAME)
+
+    # This should fail as server is presenting a self-signed certificate.
+    def test_validate_required_self_signed(self):
+        with self.settings(LDAP_AUTH_USE_TLS=True, LDAP_AUTH_TLS_VALIDATE_CERT=ssl.CERT_REQUIRED):
+            with self.assertRaises(Exception):
+                authenticate(
+                    username='any',
+                    password='any',
+                )

--- a/django_python3_ldap/tests.py
+++ b/django_python3_ldap/tests.py
@@ -464,3 +464,11 @@ class TestSSL(TestCase):
                     username='any',
                     password='any',
                 )
+
+    def test_validate_not_specified_self_signed(self):
+        with self.settings(LDAP_AUTH_USE_TLS=True):
+            with self.assertRaises(Exception):
+                authenticate(
+                    username='any',
+                    password='any',
+                )

--- a/django_python3_ldap/tests.py
+++ b/django_python3_ldap/tests.py
@@ -464,11 +464,3 @@ class TestSSL(TestCase):
                     username='any',
                     password='any',
                 )
-
-    def test_validate_not_specified_self_signed(self):
-        with self.settings(LDAP_AUTH_USE_TLS=True):
-            with self.assertRaises(Exception):
-                authenticate(
-                    username='any',
-                    password='any',
-                )


### PR DESCRIPTION
Adds support for additional options 

LDAP_AUTH_TLS_VALIDATE_CERT - Can allow ldap3 connections to be better secured with certificate validation required.
LDAP_AUTH_TLS_CIPHERS - Supports customisation of allowable SSL ciphers.
LDAP_AUTH_TLS_CA_CERTS_FILE - Allows the use of internal CA issued certificates.
LDAP_AUTH_ATTRIBUTES - Can be used to reduce the data returned from a remote LDAP server to improve performance.

All values, when set, are pass unmodified through to ldap3 where they are implemented. Defaults follow ldap3 behaviours.   