### PR TITLE
Support for pyasn1 0.5.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     install_requires=[
         "django>=1.11",
         "ldap3>=2.5,<3",
-        "pyasn1>=0.4.6,<0.5",
+        "pyasn1>=0.4.6,<0.6",
     ],
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
`pyasn1` has recently released versions 0.5.x -> https://pypi.org/project/pyasn1/#history.
This change allows for use of the recent versions as well. I noticed that this limitation was added before those versions even existed.

Tests are passing, also no apparent functional regression is observed.
