### PR TITLE
Expose ldap pool active parameter to limit retries

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,6 +94,8 @@ Available settings
     LDAP_AUTH_CONNECT_TIMEOUT = None
     LDAP_AUTH_RECEIVE_TIMEOUT = None
 
+    # Set connection pool `active` parameter on the underlying `ldap3` library.
+    LDAP_AUTH_POOL_ACTIVE = True
 
 Microsoft Active Directory support
 ----------------------------------

--- a/django_python3_ldap/conf.py
+++ b/django_python3_ldap/conf.py
@@ -136,5 +136,10 @@ class LazySettings(object):
         default=None
     )
 
+    LDAP_AUTH_POOL_ACTIVE = LazySetting(
+        name="LDAP_AUTH_POOL_ACTIVE",
+        default=True
+    )
+
 
 settings = LazySettings(settings)

--- a/django_python3_ldap/ldap.py
+++ b/django_python3_ldap/ldap.py
@@ -162,7 +162,11 @@ def connection(**kwargs):
         password = kwargs.pop("password")
         username = format_username(kwargs)
     # Build server pool
-    server_pool = ldap3.ServerPool(None, ldap3.RANDOM, active=True, exhaust=5)
+    server_pool = ldap3.ServerPool(
+        None, ldap3.RANDOM,
+        active=settings.LDAP_AUTH_POOL_ACTIVE,
+        exhaust=5
+    )
     auth_url = settings.LDAP_AUTH_URL
     if not isinstance(auth_url, list):
         auth_url = [auth_url]

--- a/django_python3_ldap/tests.py
+++ b/django_python3_ldap/tests.py
@@ -149,6 +149,18 @@ class TestLdap(TestCase):
             )
             self.assertIs(user, None)
 
+    def testAuthenticateWithLimitedRetries(self):
+        # simulate offline server
+        with self.settings(
+            LDAP_AUTH_URL=["ldap://example.com:389"],
+            LDAP_AUTH_POOL_ACTIVE=1,
+        ):
+            user = authenticate(
+                username=settings.LDAP_AUTH_TEST_USER_USERNAME,
+                password=settings.LDAP_AUTH_TEST_USER_PASSWORD,
+            )
+        self.assertEqual(user, None)
+
     # User synchronisation.
 
     def testSyncUsersCreatesUsers(self):


### PR DESCRIPTION
Currently the pool is initiated so that servers are retried indefinetely. This makes it hard to define concrete hard timeout for login operation.

This change exposes ldap3's ServerPool active parameter as setting. That way it provides means to resolve situations as with #264.

Based on the following docs: https://ldap3.readthedocs.io/en/latest/server.html#server-pool