### PR TITLE
Add additional Tls/SSL arguments

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Available settings
     import ssl
     LDAP_AUTH_TLS_VERSION = ssl.PROTOCOL_TLSv1_2
 
-    # Specify which TLS ciphers to use
+    # Specify which TLS ciphers to use.
     LDAP_AUTH_TLS_VERSION = "ALL"
 
     # Unspecified Tls keyword arguments applied to the connection on the underlying Ldap3 library.

--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,12 @@ Available settings
     import ssl
     LDAP_AUTH_TLS_VERSION = ssl.PROTOCOL_TLSv1_2
 
+    # Specify which TLS ciphers to use
+    LDAP_AUTH_TLS_VERSION = "ALL"
+
+    # Unspecified Tls keyword arguments applied to the connection on the underlying Ldap3 library.
+    LDAP_AUTH_TLS_ARGS = {}
+
     # The LDAP search base for looking up users.
     LDAP_AUTH_SEARCH_BASE = "ou=people,dc=example,dc=com"
 
@@ -90,9 +96,15 @@ Available settings
     LDAP_AUTH_CONNECTION_USERNAME = None
     LDAP_AUTH_CONNECTION_PASSWORD = None
 
+    # Use SSL on the connection
+    LDAP_AUTH_CONNECT_USE_SSL
+
     # Set connection/receive timeouts (in seconds) on the underlying `ldap3` library.
     LDAP_AUTH_CONNECT_TIMEOUT = None
     LDAP_AUTH_RECEIVE_TIMEOUT = None
+
+    # Unspecified keyword arguments to apply to the connection in the underlying ldap3 library.
+    LDAP_AUTH_CONNECT_ARGS = {}
 
 
 Microsoft Active Directory support

--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ Available settings
     LDAP_AUTH_TLS_VERSION = ssl.PROTOCOL_TLSv1_2
 
     # Specify which TLS ciphers to use.
-    LDAP_AUTH_TLS_VERSION = "ALL"
+    LDAP_AUTH_TLS_CIPHERS = "ALL"
 
     # Unspecified TLS keyword arguments applied to the connection on the underlying `ldap3` library.
     LDAP_AUTH_TLS_ARGS = {}

--- a/README.rst
+++ b/README.rst
@@ -96,8 +96,8 @@ Available settings
     LDAP_AUTH_CONNECTION_USERNAME = None
     LDAP_AUTH_CONNECTION_PASSWORD = None
 
-    # Use SSL on the connection
-    LDAP_AUTH_CONNECT_USE_SSL
+    # Use SSL on the connection.
+    LDAP_AUTH_CONNECT_USE_SSL = False
 
     # Set connection/receive timeouts (in seconds) on the underlying `ldap3` library.
     LDAP_AUTH_CONNECT_TIMEOUT = None

--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Available settings
     # Specify which TLS ciphers to use.
     LDAP_AUTH_TLS_VERSION = "ALL"
 
-    # Unspecified Tls keyword arguments applied to the connection on the underlying Ldap3 library.
+    # Unspecified TLS keyword arguments applied to the connection on the underlying `ldap3` library.
     LDAP_AUTH_TLS_ARGS = {}
 
     # The LDAP search base for looking up users.

--- a/README.rst
+++ b/README.rst
@@ -103,7 +103,7 @@ Available settings
     LDAP_AUTH_CONNECT_TIMEOUT = None
     LDAP_AUTH_RECEIVE_TIMEOUT = None
 
-    # Unspecified keyword arguments to apply to the connection in the underlying ldap3 library.
+    # Unspecified keyword arguments to apply to the connection in the underlying `ldap3` library.
     LDAP_AUTH_CONNECT_ARGS = {}
 
 

--- a/django_python3_ldap/conf.py
+++ b/django_python3_ldap/conf.py
@@ -44,9 +44,19 @@ class LazySettings(object):
         default=False,
     )
 
+    LDAP_AUTH_TLS_CIPHERS = LazySetting(
+        name="LDAP_AUTH_TLS_CIPHERS",
+        default="ALL",
+    )
+
     LDAP_AUTH_TLS_VERSION = LazySetting(
         name="LDAP_AUTH_TLS_VERSION",
         default=PROTOCOL_TLS,
+    )
+
+    LDAP_AUTH_TLS_ARGS = LazySetting(
+        name="LDAP_AUTH_TLS_ARGS",
+        default={},
     )
 
     LDAP_AUTH_SEARCH_BASE = LazySetting(
@@ -124,6 +134,16 @@ class LazySettings(object):
     LDAP_AUTH_CONNECTION_PASSWORD = LazySetting(
         name="LDAP_AUTH_CONNECTION_PASSWORD",
         default=None,
+    )
+
+    LDAP_AUTH_CONNECT_ARGS = LazySetting(
+        name="LDAP_AUTH_CONNECT_ARGS",
+        default={},
+    )
+
+    LDAP_AUTH_CONNECT_USE_SSL = LazySetting(
+        name="LDAP_AUTH_CONNECT_USE_SSL",
+        default=False,
     )
 
     LDAP_AUTH_CONNECT_TIMEOUT = LazySetting(

--- a/django_python3_ldap/ldap.py
+++ b/django_python3_ldap/ldap.py
@@ -172,11 +172,14 @@ def connection(**kwargs):
             "allowed_referral_hosts": [("*", True)],
             "get_info": ldap3.NONE,
             "connect_timeout": settings.LDAP_AUTH_CONNECT_TIMEOUT,
+            "use_ssl": settings.LDAP_AUTH_CONNECT_USE_SSL,
+            **settings.LDAP_AUTH_CONNECT_ARGS
         }
         if settings.LDAP_AUTH_USE_TLS:
             server_args["tls"] = ldap3.Tls(
-                ciphers="ALL",
+                ciphers=settings.LDAP_AUTH_TLS_CIPHERS,
                 version=settings.LDAP_AUTH_TLS_VERSION,
+                **settings.LDAP_AUTH_TLS_ARGS
             )
         server_pool.add(
             ldap3.Server(


### PR DESCRIPTION
I'm running an LDAP server with a handful of old/legacy settings required, which causes this to fail to connect. Pullrequest adds support for entering those settings, and support for other unnamed options through keyword arguments.