### PR TITLE
Pass multi-valued fields to `clean_user_data`

### DIFF
--- a/django_python3_ldap/ldap.py
+++ b/django_python3_ldap/ldap.py
@@ -11,12 +11,10 @@ from django.contrib.auth import get_user_model
 from django_python3_ldap.conf import settings
 from django_python3_ldap.utils import import_func, format_search_filter
 
-
 logger = logging.getLogger(__name__)
 
 
 class Connection(object):
-
     """
     A connection to an LDAP server.
     """
@@ -46,11 +44,9 @@ class Connection(object):
 
         # Create the user data.
         user_fields = {
-            field_name: (
-                attributes[attribute_name][0]
-                if isinstance(attributes[attribute_name], (list, tuple)) else
-                attributes[attribute_name]
-            )
+            field_name: attributes[attribute_name][0]
+            if len(attributes[attribute_name]) == 1
+            else attributes[attribute_name]
             for field_name, attribute_name
             in settings.LDAP_AUTH_USER_FIELDS.items()
             if attribute_name in attributes
@@ -219,7 +215,7 @@ def connection(**kwargs):
         )
         settings_password = settings.LDAP_AUTH_CONNECTION_PASSWORD
         if (settings_username or settings_password) and (
-            settings_username != username or settings_password != password
+                settings_username != username or settings_password != password
         ):
             c.rebind(
                 user=settings_username,

--- a/django_python3_ldap/utils.py
+++ b/django_python3_ldap/utils.py
@@ -64,6 +64,10 @@ def clean_user_data(model_fields):
     Transforms the user data loaded from
     LDAP into a form suitable for creating a user.
     """
+    for field in model_fields:
+        if isinstance(model_fields[field], (list, tuple)):
+            model_fields[field] = model_fields[field][0]
+
     return model_fields
 
 


### PR DESCRIPTION
Resolves #276 

Breaks backwards compatibility slightly in that it may pass lists as input to `clean_user_data`, which may break already existing custom implementations of it, but the fix is easy.