### PR TITLE
Implemented functionalities to allow multiple LDAP configs

### DIFF
--- a/django_python3_ldap/auth.py
+++ b/django_python3_ldap/auth.py
@@ -20,4 +20,7 @@ class LDAPBackend(ModelBackend):
     supports_inactive_user = False
 
     def authenticate(self, *args, **kwargs):
+        if hasattr(self, 'PREFIX'):
+            kwargs = dict(kwargs, prefix=self.PREFIX)
+
         return ldap.authenticate(*args, **kwargs)

--- a/django_python3_ldap/conf.py
+++ b/django_python3_ldap/conf.py
@@ -19,7 +19,13 @@ class LazySetting(object):
     def __get__(self, obj, cls):
         if obj is None:
             return self
-        return getattr(obj._settings, self.name, self.default)
+
+        property_name = self.name
+
+        if hasattr(obj._settings, (name_with_prefix := obj._prefix + self.name)):
+            property_name = name_with_prefix
+
+        return getattr(obj._settings, property_name, self.default)
 
 
 class LazySettings(object):
@@ -31,8 +37,19 @@ class LazySettings(object):
     to change settings at runtime.
     """
 
-    def __init__(self, settings):
+    def __init__(self, settings, prefix=''):
         self._settings = settings
+        self._prefix = prefix
+
+    def set_or_clear_prefix(self, new_prefix=''):
+        """
+        Setter method for the _prefix property, is called before each authentication.
+        This allows users to use multiple LDAP configs at the same time.
+
+        Args:
+            new_prefix (str, optional): The string that should be appended to the default constant names. Defaults to an empty string.
+        """
+        self._prefix = new_prefix
 
     LDAP_AUTH_URL = LazySetting(
         name="LDAP_AUTH_URL",

--- a/django_python3_ldap/ldap.py
+++ b/django_python3_ldap/ldap.py
@@ -251,6 +251,12 @@ def authenticate(*args, **kwargs):
     in settings.LDAP_AUTH_USER_LOOKUP_FIELDS, plus a `password` argument.
     """
     password = kwargs.pop("password", None)
+
+    if settings_prefix := kwargs.pop("prefix"):
+        settings.set_or_clear_prefix(settings_prefix)
+    else:
+        settings.set_or_clear_prefix()
+
     auth_user_lookup_fields = frozenset(settings.LDAP_AUTH_USER_LOOKUP_FIELDS)
     ldap_kwargs = {
         key: value for (key, value) in kwargs.items()


### PR DESCRIPTION
Hey there! I had to use multiple configurations for my Django Application and i was already using this package, so I tried to implement the functionality myself. I've tested it a bit and up until now it seems to be working, but it's still only a draft.

With this implementation, the user would need to implement a subclass of the LDAP Backend class

```python
class MyBackend(LDAPBackend):
    PREFIX = 'MY_PREFIX_'
```

and add the required constants to the settings.py file (if the values are different from the ones without a prefix, else the code will automatically use those, which also allows it to be backwards-compatible)

```python

AUTHENTICATION_BACKENDS = [
    'custom_backends.MyBackend',
    'django_python3_ldap.auth.LDAPBackend',
    'django.contrib.auth.backends.ModelBackend',
]

# Uses different configs for each Backends
LDAP_AUTH_URL = 'ldap://my_ldap:1234'
MY_PREFIX_LDAP_AUTH_URL = f'ldap://my_other_ldap:4321'

# Uses same config for both Backends
LDAP_AUTH_OBJECT_CLASS = '*'

```

What do you think about it?