### PR TITLE
Implement Asynchronous Authenticate Method

### DIFF
--- a/django_python3_ldap/auth.py
+++ b/django_python3_ldap/auth.py
@@ -1,10 +1,18 @@
 """
 Django authentication backend.
 """
-
+from asgiref.sync import sync_to_async
 from django.contrib.auth.backends import ModelBackend
 
 from django_python3_ldap import ldap
+
+
+@sync_to_async
+def run_authentication_async(*args, **kwargs):
+    """
+    Executes the ldap.authenticate function, wrapped in asynchronous execution.
+    """
+    return ldap.authenticate(*args, **kwargs)
 
 
 class LDAPBackend(ModelBackend):
@@ -21,3 +29,6 @@ class LDAPBackend(ModelBackend):
 
     def authenticate(self, *args, **kwargs):
         return ldap.authenticate(*args, **kwargs)
+
+    async def aauthenticate(self, *args, **kwargs):
+        return await run_authentication_async(*args, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         "django>=1.11",
+        "asgiref>=2.0.0",
         "ldap3>=2.5,<3",
         "pyasn1>=0.4.6,<0.6",
     ],


### PR DESCRIPTION
This PR resolves #284. The primary changes are as follows:

1. `asgiref` is added to the `install_requires` in `setup.py`. This is done because the `sync_to_async` and `async_to_sync` functions are provided from `asgiref` 2.0.0 onward. Django distributions with async support automatically install `asgiref`, so the vast majority of the time this dependency should already be available.
2. A `aauthenticate` method is implemented in `LDAPBackend`, which runs a simple async wrapper around `ldap.authenticate` called `run_authentication_async`.
3. Adds a test `testAuthenticateAsyncRunner`, which checks that `run_authentication_async` calls `ldap.authenticate` as expected.