### PR TITLE
Allow for association with session user

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,6 +109,11 @@ Available settings
     # Set connection pool `active` parameter on the underlying `ldap3` library.
     LDAP_AUTH_POOL_ACTIVE = True
 
+    # Whether an LDAP login as part of an existing user session (for example due to a prior login using a different
+    # authentication backend) should update the existing user object and preserve the user in the session instead
+    # of creating a new user object.
+    LDAP_AUTH_ASSOCIATE_EXISTING_USER = False
+
 Microsoft Active Directory support
 ----------------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -176,6 +176,8 @@ The parameters are:-
 - ``connection`` - the LDAP connection object (optional keyword only parameter)
 - ``dn`` - the DN (Distinguished Name) of the LDAP matched user (optional keyword only parameter)
 
+The function can optionally return a user object to forward to ``authenticate()`` instead of the original user.
+This is useful in combination with ``LDAP_AUTH_ASSOCIATE_EXISTING_USER``.
 
 Clean User
 ----------

--- a/django_python3_ldap/conf.py
+++ b/django_python3_ldap/conf.py
@@ -161,5 +161,10 @@ class LazySettings(object):
         default=True
     )
 
+    LDAP_AUTH_ASSOCIATE_EXISTING_USER = LazySetting(
+        name="LDAP_AUTH_ASSOCIATE_EXISTING_USER",
+        default=False
+    )
+
 
 settings = LazySettings(settings)

--- a/django_python3_ldap/ldap.py
+++ b/django_python3_ldap/ldap.py
@@ -89,7 +89,9 @@ class Connection(object):
             else:
                 raise TypeError(f"Unknown kw argument {argname} in signature for LDAP_AUTH_SYNC_USER_RELATIONS")
         # call sync_user_relations_func() with original args plus supported named extras
-        sync_user_relations_func(user, attributes, **args)
+        sync_user = sync_user_relations_func(user, attributes, **args)
+        if sync_user is not None:
+            user = sync_user
         # All done!
         logger.info("LDAP user lookup succeeded")
         return user


### PR DESCRIPTION
1.
    Allow for association with session user

    In environments with multiple authentication backends it can be
    desirable to link an LDAP login with an existing user.

2.
    Allow sync relation function to return user

    If existing users are associated, it can be useful to similarly compare
    an LDAP login with a model containing users created through different
    backends, and further to use a found user object instead of creating a
    new one.